### PR TITLE
[NEW-FEATURE] When an added property of string contains localization attributes it should use translator

### DIFF
--- a/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertyDeclarationAstNode.cs
+++ b/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertyDeclarationAstNode.cs
@@ -26,6 +26,27 @@ internal class AddedPropertyDeclarationAstNode : AstNode
 
     public override void AcceptVisitor(IAstVisitor visitor)
     {
-        if (visitor is PragmaVisitor v) v.Product = $"{AccessQualifier} {Type} {Identifier} {{ get; set; }}";
+        if (visitor is PragmaVisitor v)
+        {
+            if (Type.ToUpperInvariant() == "STRING")
+            {
+                v.Product = $"private {Type} _{Identifier};" +
+                            $"\n{AccessQualifier} {Type} {Identifier} " +
+                            $"{{ " +
+                            $"get" +
+                            $"{{ " +
+                            $"return Ix.Localizations.LocalizationHelper.CleanUpLocalizationTokens(_{Identifier}); " +
+                            $"}} " +
+                            $"set; " +
+                            $"{{_{Identifier} = value;" +
+                            $"}} " +
+                            $"}}";
+            }
+            else
+            {
+                v.Product = $"{AccessQualifier} {Type} {Identifier} {{ get; set; }}";
+            }
+           
+        }
     }
 }

--- a/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertySetterAstNode.cs
+++ b/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertySetterAstNode.cs
@@ -30,6 +30,7 @@ internal class AddedPropertySetterAstNode : AstNode
 
     public override void AcceptVisitor(IAstVisitor visitor)
     {
+
         if (visitor is PragmaVisitor v)
             v.Product = MemberName != null
                 ? $"{MemberName}.{PropertyName} = {InitValue};"

--- a/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/Ast/AttributeDeclarationAstNode.cs
+++ b/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/Ast/AttributeDeclarationAstNode.cs
@@ -11,7 +11,7 @@ using Irony.Parsing;
 
 namespace Ix.Compiler.Cs.Pragmas.PragmaParser;
 
-internal class DeclarationAttributeAstNode : AstNode
+internal class AttributeDeclarationAstNode : AstNode
 {
     public string? AttributeLiteral { get; set; }
 

--- a/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/PragmaGrammar.cs
+++ b/src/ix.compiler/src/IX.Cs.Compiler/Pragmas/PragmaParser/PragmaGrammar.cs
@@ -34,7 +34,7 @@ internal class PragmaGrammar : Grammar
     public readonly NonTerminal AddedPropertySetter = new(nameof(AddedPropertySetter), typeof(AddedPropertySetterAstNode));
     public readonly Terminal assing = new(nameof(assing));
 
-    public readonly NonTerminal DeclarationAttribute = new(nameof(DeclarationAttribute), typeof(DeclarationAttributeAstNode));
+    public readonly NonTerminal DeclarationAttribute = new(nameof(DeclarationAttribute), typeof(AttributeDeclarationAstNode));
     public readonly NonTerminal ClrAttribute = new(nameof(ClrAttribute));
 
     public readonly FreeTextLiteral ClrAttributeContent =

--- a/src/ix.compiler/tests/Ix.Compiler.CsTests/Cs/PragmasExtensionsTests.cs
+++ b/src/ix.compiler/tests/Ix.Compiler.CsTests/Cs/PragmasExtensionsTests.cs
@@ -58,7 +58,7 @@ public class PragmasExtensionsTests
     [Fact]
     public void should_declare_property()
     {
-        var expected = "public string AttributeName { get; set; }";
+        var expected = "private string _AttributeName;\npublic string AttributeName { get{ return Ix.Localizations.LocalizationHelper.CleanUpLocalizationTokens(_AttributeName); } set; {_AttributeName = value;} }";
         var field = new TypeMock("someField",
             new ReadOnlyCollection<IPragma>(new IPragma[]
             {

--- a/src/ix.compiler/tests/Ix.Compiler.CsTests/samples/units/expected/.g/Onliners/types_with_name_attributes.g.cs
+++ b/src/ix.compiler/tests/Ix.Compiler.CsTests/samples/units/expected/.g/Onliners/types_with_name_attributes.g.cs
@@ -258,7 +258,19 @@ namespace TypeWithNameAttributes
 
     public partial class NoAccessModifierClass : Ix.Connector.ITwinObject
     {
-        public string AttributeName { get; set; }
+        private string _AttributeName;
+        public string AttributeName
+        {
+            get
+            {
+                return Ix.Localizations.LocalizationHelper.CleanUpLocalizationTokens(_AttributeName);
+            }
+
+            set;
+            {
+                _AttributeName = value;
+            }
+        }
 
         public OnlinerString SomeClassVariable { get; }
 

--- a/src/ix.compiler/tests/Ix.Compiler.CsTests/samples/units/expected/.g/Onliners/types_with_property_attributes.g.cs
+++ b/src/ix.compiler/tests/Ix.Compiler.CsTests/samples/units/expected/.g/Onliners/types_with_property_attributes.g.cs
@@ -7,7 +7,19 @@ namespace TypesWithPropertyAttributes
 {
     public partial class SomeAddedProperties : Ix.Connector.ITwinObject
     {
-        public string Description { get; set; }
+        private string _Description;
+        public string Description
+        {
+            get
+            {
+                return Ix.Localizations.LocalizationHelper.CleanUpLocalizationTokens(_Description);
+            }
+
+            set;
+            {
+                _Description = value;
+            }
+        }
 
         public OnlinerInt Counter { get; }
 

--- a/src/ix.connectors/src/Ix.Connector/Localizations/LocalizationHelper.cs
+++ b/src/ix.connectors/src/Ix.Connector/Localizations/LocalizationHelper.cs
@@ -81,7 +81,7 @@ public static class LocalizationHelper
         return localizables;
     }
 
-    internal static string CleanUpLocalizationTokens(string localized)
+    public static string CleanUpLocalizationTokens(this string localized)
     {
         if (localized != null) return localized.Replace("<#", string.Empty).Replace("#>", string.Empty);
 


### PR DESCRIPTION
This addresses the problem temporarily. The issue will be fully addressed in #98 

closes #96