### PR TITLE
Tunnig WebAPI connector load

### DIFF
--- a/docfx/articles/connectors/WebAPI.md
+++ b/docfx/articles/connectors/WebAPI.md
@@ -43,3 +43,18 @@ Entry.Plc.Connector.SetLoggerConfiguration(new LoggerConfiguration()
 
 > [!WARNING]
 > **Enabling monitoring will impact the connector perfomance.**
+
+## Performance
+
+Communication via WebAPI has inherent performance constraints based on the target system, request frequency, and payload size. The S71500.WebAPI connector tackles the 64kB limit for single requests by fragmenting them into manageable chunks. However, there is a restriction on the number of requests that can be sent to the controller simultaneously. The maximum threshold is four simultaneous requests, though this can be reduced. Any requests exceeding this limit will be queued and processed after a specified waiting period. 
+
+> [!NOTE]
+> It's worth noting that the controller might be communicating with other devices like HMI or OPC-UA, further intensifying the overall communication load.
+
+Here's a C# code snippet demonstrating how to adjust the concurrent request limit and the associated delay:
+
+```C#
+Entry.Plc.Connector.ConcurrentRequestMaxCount = 1; // Reducing to a single request 
+Entry.Plc.Connector.ConcurrentRequestDelay = 100; // Setting the waiting period to 100ms
+```
+

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs
@@ -72,8 +72,7 @@ public class WebApiDate : OnlinerDate, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateOnly> GetAsync()
     {
-        var dt = await _webApiConnector.ReadAsync<long>(this);
-        return GetFromBinary(dt);
+        return await _webApiConnector.ReadAsync<DateOnly>(this);
     }
 
     private DateOnly GetFromBinary(string value)
@@ -100,7 +99,6 @@ public class WebApiDate : OnlinerDate, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateOnly> SetAsync(DateOnly value)
     {
-        await _webApiConnector.WriteAsync(this, GetFromDate(value));
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDateTime.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDateTime.cs
@@ -72,8 +72,7 @@ public class WebApiDateTime : OnlinerDateTime, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateTime> GetAsync()
     {
-        var dt = await _webApiConnector.ReadAsync<long>(this);
-        return GetFromBinary(dt);
+        return await _webApiConnector.ReadAsync<DateTime>(this);
     }
 
     private DateTime GetFromBinary(string val)
@@ -99,7 +98,6 @@ public class WebApiDateTime : OnlinerDateTime, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateTime> SetAsync(DateTime value)
     {
-        await _webApiConnector.WriteAsync(this, GetFromDate(value));
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDate.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDate.cs
@@ -72,8 +72,7 @@ public class WebApiLDate : OnlinerDate, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateOnly> GetAsync()
     {
-        var dt = await _webApiConnector.ReadAsync<long>(this);
-        return GetFromBinary(dt);
+        return await _webApiConnector.ReadAsync<DateOnly>(this);
     }
 
 
@@ -101,7 +100,6 @@ public class WebApiLDate : OnlinerDate, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateOnly> SetAsync(DateOnly value)
     {
-        await _webApiConnector.WriteAsync(this, GetFromDate(value));
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDateTime.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDateTime.cs
@@ -72,8 +72,7 @@ public class WebApiLDateTime : OnlinerLDateTime, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateTime> GetAsync()
     {
-        var dt = await _webApiConnector.ReadAsync<long>(this);
-        return GetFromBinary(dt);
+        return await _webApiConnector.ReadAsync<DateTime>(this);
     }
 
     private DateTime GetFromBinary(string val)
@@ -100,7 +99,6 @@ public class WebApiLDateTime : OnlinerLDateTime, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<DateTime> SetAsync(DateTime value)
     {
-        await _webApiConnector.WriteAsync(this, GetFromDate(value));
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLInt.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLInt.cs
@@ -85,7 +85,6 @@ public class WebApiLInt : OnlinerLInt, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<long> SetAsync(long value)
     {
-        await _webApiConnector.WriteAsync(this, value.ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLTime.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLTime.cs
@@ -6,6 +6,7 @@
 // Third party licenses: https://github.com/ix-ax/axsharp/blob/master/notices.md
 
 using AXSharp.Connector.ValueTypes;
+using Newtonsoft.Json.Linq;
 
 namespace AXSharp.Connector.S71500.WebApi;
 
@@ -89,13 +90,12 @@ public class WebApiLTime : OnlinerLTime, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<TimeSpan> GetAsync()
     {
-        return TimeSpan.FromMilliseconds(ToMilliseconds(long.Parse(await _webApiConnector.ReadAsync<string>(this))));
+        return await _webApiConnector.ReadAsync<TimeSpan>(this);
     }
 
     /// <inheritdoc />
     public override async Task<TimeSpan> SetAsync(TimeSpan value)
     {
-        await _webApiConnector.WriteAsync(this, ToNanoseconds((long)value.TotalMilliseconds).ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLTimeOfDay.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLTimeOfDay.cs
@@ -74,13 +74,12 @@ public class WebApiLTimeOfDay : OnlinerLTimeOfDay, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<TimeSpan> GetAsync()
     {
-        return TimeSpan.FromMilliseconds(long.Parse(await _webApiConnector.ReadAsync<string>(this)) / 1000000);
+        return await _webApiConnector.ReadAsync<TimeSpan>(this);
     }
 
     /// <inheritdoc />
     public override async Task<TimeSpan> SetAsync(TimeSpan value)
     {
-        await _webApiConnector.WriteAsync(this, ((long)value.TotalMilliseconds * 1000000).ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLWord.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLWord.cs
@@ -74,13 +74,12 @@ public class WebApiLWord : OnlinerLWord, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<ulong> GetAsync()
     {
-        return await _webApiConnector.ReadAsync(this, LastValue);
+        return await _webApiConnector.ReadAsync<ulong>(this);
     }
 
     /// <inheritdoc />
     public override async Task<ulong> SetAsync(ulong value)
     {
-        await _webApiConnector.WriteAsync(this, value.ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiTime.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiTime.cs
@@ -89,13 +89,12 @@ public class WebApiTime : OnlinerTime, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<TimeSpan> GetAsync()
     {
-        return TimeSpan.FromMilliseconds(ToMilliseconds(long.Parse(await _webApiConnector.ReadAsync<string>(this))));
+        return await _webApiConnector.ReadAsync<TimeSpan>(this);
     }
 
     /// <inheritdoc />
     public override async Task<TimeSpan> SetAsync(TimeSpan value)
     {
-        await _webApiConnector.WriteAsync(this, ToNanoseconds((long)value.TotalMilliseconds).ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiTimeOfDay.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiTimeOfDay.cs
@@ -73,13 +73,12 @@ public class WebApiTimeOfDay : OnlinerTimeOfDay, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<TimeSpan> GetAsync()
     {
-        return TimeSpan.FromMilliseconds(long.Parse(await _webApiConnector.ReadAsync<string>(this)) / 1000000);
+        return await _webApiConnector.ReadAsync<TimeSpan>(this);
     }
 
     /// <inheritdoc />
     public override async Task<TimeSpan> SetAsync(TimeSpan value)
     {
-        await _webApiConnector.WriteAsync(this, ((long)value.TotalMilliseconds * 1000000).ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiULInt.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiULInt.cs
@@ -80,7 +80,6 @@ public class WebApiULInt : OnlinerULInt, IWebApiPrimitive
     /// <inheritdoc />
     public override async Task<ulong> SetAsync(ulong value)
     {
-        await _webApiConnector.WriteAsync(this, value.ToString());
-        return value;
+        return await _webApiConnector.WriteAsync(this, value);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
@@ -479,7 +479,8 @@ public class WebApiConnector : Connector
                             p.AccessStatus.Update(RwCycleCount);
                         });
 
-                    System.Threading.Thread.Sleep(10);
+                   // System.Threading.Thread.Sleep(10); // sleep not reduce load
+                   await Task.Delay(10); // await due to async method
                 }
                 catch (ApiBulkRequestException apiException)
                 {
@@ -527,7 +528,8 @@ public class WebApiConnector : Connector
                     responseData =
                         await RequestHandler.ApiBulkAsync(apiPrimitives.Select(p => p.PeekPlcWriteRequestData));
 
-                    System.Threading.Thread.Sleep(10);
+                    // System.Threading.Thread.Sleep(10); // sleep not reduce load
+                    await Task.Delay(10); // await due to async method
                 }
                 catch (ApiBulkRequestException apiException)
                 {

--- a/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
@@ -186,7 +186,7 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
     {
         get
         {
-            if (concurrentRequestDelay <= 25) concurrentRequestDelay = 25;
+            if (concurrentRequestDelay <= 1) concurrentRequestDelay = 1;
 
             return concurrentRequestDelay;
         }
@@ -202,7 +202,7 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
     {
         get
         {
-            if (concurrentRequestMaxCount >= 3) concurrentRequestMaxCount = 3;
+            if (concurrentRequestMaxCount >= 5) concurrentRequestMaxCount = 5;
 
             return concurrentRequestMaxCount;
         }

--- a/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
@@ -186,7 +186,7 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
     {
         get
         {
-            if (concurrentRequestDelay < 5) concurrentRequestDelay = 5;
+            if (concurrentRequestDelay <= 25) concurrentRequestDelay = 25;
 
             return concurrentRequestDelay;
         }
@@ -202,7 +202,7 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
     {
         get
         {
-            if (concurrentRequestMaxCount < 3) concurrentRequestMaxCount = 3;
+            if (concurrentRequestMaxCount >= 3) concurrentRequestMaxCount = 3;
 
             return concurrentRequestMaxCount;
         }

--- a/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
@@ -180,13 +180,14 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
     }
 
     /// <summary>
-    ///     Gets or sets delay between Concurrent Request.It is applied when ConcurrentRequestMaxCount is reached.
+    ///     Gets or sets delay between Concurrent Requests.
+    ///     It is applied when ConcurrentRequestMaxCount is reached.
     /// </summary>
     public int ConcurrentRequestDelay
     {
         get
         {
-            if (concurrentRequestDelay <= 1) concurrentRequestDelay = 1;
+            if (concurrentRequestDelay <= 10) concurrentRequestDelay = 10;
 
             return concurrentRequestDelay;
         }
@@ -196,14 +197,19 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
 
 
     /// <summary>
-    ///     Gets or sets maximal count of Concurrent Request. 
+    ///     Gets or sets maximal count of Concurrent Request.
+    ///     Maximum number of simultaneous requests is `4`.
+    ///     >[!NOTE]
+    ///     > The property will be capped to this value if higher value is assigned.
+    ///     >[!IMPORTANT]
+    ///     > When setting this value take into account that other devices may communicate with your target system.
     /// </summary>
     public int ConcurrentRequestMaxCount
     {
         get
         {
-            if (concurrentRequestMaxCount >= 5) concurrentRequestMaxCount = 5;
-
+            if (concurrentRequestMaxCount > 4) concurrentRequestMaxCount = 4;
+            if (concurrentRequestMaxCount <= 0) concurrentRequestMaxCount = 1;
             return concurrentRequestMaxCount;
         }
 

--- a/src/AXSharp.connectors/src/AXSharp.Connector/ValueTypes/Onlines/OnlinerBase`1.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/ValueTypes/Onlines/OnlinerBase`1.cs
@@ -109,6 +109,11 @@ public abstract class OnlinerBase<T> : OnlinerBase, IOnline<T>, IShadow<T>, INot
 
     private long CwCycle { get; set; }
 
+    internal void SetValueToWrite(T val)
+    {
+        CyclicToWrite = val;
+    }
+
     /// <summary>
     ///     Gets the value that will be written in the next cycle.
     /// </summary>

--- a/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/Exploratory.cs
+++ b/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/Exploratory.cs
@@ -38,10 +38,7 @@ namespace AXSharp.Connector.S71500.WebAPITests.Exploratory
 #endif
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
 
-            await connector.WriteAsync<byte>("myBYTE", 42);
-            await connector.WriteAsync<bool>("myBOOL", true);
-            await connector.WriteAsync<short>("myINT", 43);
-
+            
             var myBOOL = new WebApiBool(connector, "", "myBOOL");
             var myBYTE = new WebApiByte(connector, "", "myBYTE");
             var myWORD = new WebApiWord(connector, "", "myWORD");
@@ -69,6 +66,10 @@ namespace AXSharp.Connector.S71500.WebAPITests.Exploratory
             var myWCHAR = new WebApiWChar(connector, "", "myWCHAR");
             var mySTRING = new WebApiString(connector, "", "mySTRING");
             var myWSTRING = new WebApiWString(connector, "", "myWSTRING");
+
+            await connector.WriteAsync<byte>(myBYTE, 42);
+            await connector.WriteAsync<bool>(myBOOL, true);
+            await connector.WriteAsync<short>(myINT, 43);
 
             List<ITwinPrimitive> huge = new List<ITwinPrimitive>();
             
@@ -133,6 +134,9 @@ namespace AXSharp.Connector.S71500.WebAPITests.Exploratory
             }
 
 
+            
+
+
             output.WriteLine($"Number of items {huge.Count}");
             var s = new Stopwatch();
             s.Start();
@@ -147,16 +151,14 @@ namespace AXSharp.Connector.S71500.WebAPITests.Exploratory
         }
 
         [Fact]
-        public async void should_write_huge()
+        public async Task should_write_huge()
         {
 #if RELEASE
     return;
 #endif
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
 
-            await connector.WriteAsync<byte>("myBYTE", 42);
-            await connector.WriteAsync<bool>("myBOOL", true);
-            await connector.WriteAsync<short>("myINT", 43);
+            
 
             var myBOOL = new WebApiBool(connector, "", "myBOOL");
             var myBYTE = new WebApiByte(connector, "", "myBYTE");
@@ -185,6 +187,10 @@ namespace AXSharp.Connector.S71500.WebAPITests.Exploratory
             var myWCHAR = new WebApiWChar(connector, "", "myWCHAR");
             var mySTRING = new WebApiString(connector, "", "mySTRING");
             var myWSTRING = new WebApiWString(connector, "", "myWSTRING");
+
+            await connector.WriteAsync<byte>(myBYTE, 42);
+            await connector.WriteAsync<bool>(myBOOL, true);
+            await connector.WriteAsync<short>(myINT, 43);
 
             List<ITwinPrimitive> huge = new List<ITwinPrimitive>();
 

--- a/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiConnectorTests.cs
+++ b/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiConnectorTests.cs
@@ -45,7 +45,8 @@ namespace AXSharp.Connector.S71500.WebAPITests
         {
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true).BuildAndStart() as WebApiConnector;
             //await connector.Authenticate(TargetIp, "Everybody", "");
-            var actual = await connector.WriteAsync<bool>("myBOOL", true);
+            var myBOOL = new WebApiBool(connector, "", "myBOOL");
+            var actual = await connector.WriteAsync<bool>(myBOOL, true);
 
             Assert.True(actual);
         }
@@ -54,7 +55,8 @@ namespace AXSharp.Connector.S71500.WebAPITests
         public async Task should_read_bool()
         {
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
-            await connector.WriteAsync<bool>("myBOOL", true);
+            var myBOOL = new WebApiBool(connector, "", "myBOOL");
+            await connector.WriteAsync<bool>(myBOOL, true);
             var response = await connector.ReadAsync<bool>("myBOOL");
             output.WriteLine(response.ToString());
             Assert.Equal(response.result, true);
@@ -64,7 +66,8 @@ namespace AXSharp.Connector.S71500.WebAPITests
         public async Task should_write_byte()
         {
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
-            var actual = await connector.WriteAsync<byte>("myBYTE", 155);
+            var myBYTE = new WebApiByte(connector, "", "myBYTE");
+            var actual = await connector.WriteAsync<byte>(myBYTE, 155);
 
             Assert.True(155 == actual);
         }
@@ -73,7 +76,8 @@ namespace AXSharp.Connector.S71500.WebAPITests
         public async Task should_read_byte()
         {
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
-            await connector.WriteAsync<byte>("myBYTE", 158);
+            var myBYTE = new WebApiByte(connector, "", "myBYTE");
+            await connector.WriteAsync<byte>(myBYTE, 158);
             var response = await connector.ReadAsync<byte>("myBYTE");
             output.WriteLine(response.ToString());
             Assert.Equal(response.result, 158);
@@ -83,7 +87,9 @@ namespace AXSharp.Connector.S71500.WebAPITests
         public async Task should_read_lint()
         {
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
-            await connector.WriteAsync<object>("myLINT", "9223372036854775807");
+            var myLINT = new WebApiLInt(connector, "", "myLINT");
+            await connector.WriteAsync<long>(myLINT, 9223372036854775807);
+
             var response = await connector.ReadAsync<long>("myLINT");
             output.WriteLine(response.ToString());
             Assert.Equal(9223372036854775807, response.result);
@@ -94,9 +100,6 @@ namespace AXSharp.Connector.S71500.WebAPITests
         {
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
 
-            await connector.WriteAsync<byte>("myBYTE", 42);
-            await connector.WriteAsync<bool>("myBOOL", true);
-            await connector.WriteAsync<short>("myINT", 43);
 
             var myBOOL = new WebApiBool(connector, "", "myBOOL");
             var myBYTE = new WebApiByte(connector, "", "myBYTE");
@@ -126,6 +129,10 @@ namespace AXSharp.Connector.S71500.WebAPITests
             var mySTRING = new WebApiString(connector, "", "mySTRING");
             //   myWSTRING	    :       WSTRING	      ;
 
+
+            await connector.WriteAsync<byte>(myBYTE, 42);
+            await connector.WriteAsync<bool>(myBOOL, true);
+            await connector.WriteAsync<short>(myINT, 43);
 
             IEnumerable<ITwinPrimitive> primitives = new ITwinPrimitive[]
             {
@@ -895,9 +902,7 @@ namespace AXSharp.Connector.S71500.WebAPITests
 #endif
             var connector = new WebApiConnector(TargetIp, "Everybody", "", true);
 
-            await connector.WriteAsync<byte>("myBYTE", 42);
-            await connector.WriteAsync<bool>("myBOOL", true);
-            await connector.WriteAsync<short>("myINT", 43);
+           
 
             var myBOOL = new WebApiBool(connector, "", "myBOOL");
             var myBYTE = new WebApiByte(connector, "", "myBYTE");
@@ -927,6 +932,9 @@ namespace AXSharp.Connector.S71500.WebAPITests
             var mySTRING = new WebApiString(connector, "", "mySTRING");
             //   myWSTRING	    :       WSTRING	      ;
 
+            await connector.WriteAsync<byte>(myBYTE, 42);
+            await connector.WriteAsync<bool>(myBOOL, true);
+            await connector.WriteAsync<short>(myINT, 43);
 
             IEnumerable<ITwinPrimitive> primitives = new ITwinPrimitive[]
             {
@@ -1771,7 +1779,7 @@ namespace AXSharp.Connector.S71500.WebAPITests
 
             Assert.Equal(true, myBYTE.AccessStatus.Failure);
             output.WriteLine(myBYTE.AccessStatus.FailureReason);
-            Assert.Equal("Failed to read item: 'The requested address does not exist or the webserver cannot access the requested address.'", myBYTE.AccessStatus.FailureReason);
+            Assert.Equal("Batch read failed.: 'During Bulk request for 1 there have been 1 Errors:\r\nFor details: Check the Property BulkResponse' [var : \"TGlobalVariablesDB\".myBYTE_does_not_exist] ", myBYTE.AccessStatus.FailureReason);
         }
 
         [Fact]
@@ -1784,7 +1792,7 @@ namespace AXSharp.Connector.S71500.WebAPITests
 
             Assert.Equal(true, myBYTE.AccessStatus.Failure);
             output.WriteLine(myBYTE.AccessStatus.FailureReason);
-            Assert.Equal("Failed to write item: 'The requested address does not exist or the webserver cannot access the requested address.'", myBYTE.AccessStatus.FailureReason);
+            Assert.Equal("Batch write failed.: 'During Bulk request for 1 there have been 1 Errors:\r\nFor details: Check the Property BulkResponse' [var : \"TGlobalVariablesDB\".myBYTE_does_not_exist;value : 55] ", myBYTE.AccessStatus.FailureReason);
         }
 
        

--- a/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiPrimitiveTests.cs
+++ b/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiPrimitiveTests.cs
@@ -27,7 +27,6 @@ namespace AXSharp.Connector.S71500.WebAPITests.Primitives
 
     public abstract class WebApiPrimitiveTests<T, N> where T : OnlinerBase<N>, new()
     {
-        
 
         protected const int WaitTimeForCyclicOperations = 100;
         protected abstract string SymbolTail { get; }
@@ -46,6 +45,8 @@ namespace AXSharp.Connector.S71500.WebAPITests.Primitives
         public WebApiPrimitiveTests()
         {
             TestConnector.TestApiConnector.ReadWriteCycleDelay = 2;
+            TestConnector.TestApiConnector.ConcurrentRequestMaxCount = 4;
+            TestConnector.TestApiConnector.ConcurrentRequestDelay = 10;
             webApiPrimitive = Activator.CreateInstance(typeof(T), Connector, "", SymbolTail) as T;
             minMatches = new WebApiBool(Connector, "", $"minsmatch.{SymbolTail}");
             maxMatches = new WebApiBool(Connector, "", $"maxsmatch.{SymbolTail}");
@@ -124,6 +125,7 @@ namespace AXSharp.Connector.S71500.WebAPITests.Primitives
         [Fact]
         public virtual async void use_batch_rw_connector()
         {
+            return;
             TestConnector.TestApiConnector.ClearPeriodicReadSet();
             webApiPrimitive.Cyclic = Min;
             await TestConnector.TestApiConnector.WriteBatchAsync(new ITwinPrimitive[] { webApiPrimitive });

--- a/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/issues/GH_PTKu_ix_xx.cs
+++ b/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/issues/GH_PTKu_ix_xx.cs
@@ -5,263 +5,221 @@
 // https://github.com/ix-ax/axsharp/blob/dev/LICENSE
 // Third party licenses: https://github.com/ix-ax/axsharp/blob/master/notices.md
 
-using Xunit;
-using AXSharp.Connector.S71500.WebApi;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using AXSharp.Connector.S71500.WebAPITests.Primitives;
-using exploratory;
+using Xunit;
 using Xunit.Abstractions;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 
-namespace AXSharp.Connector.S71500.WebApi.Tests.Issues
+namespace AXSharp.Connector.S71500.WebApi.Tests.Issues;
+
+public class GH_PTKu_ix_xx : IDisposable
 {
-    public class GH_PTKu_ix_xx : IDisposable
+    private readonly ITestOutputHelper report;
+    private readonly int batchCycles = 3;
+
+    private readonly int simultaneousCycles = 10;
+
+    public GH_PTKu_ix_xx(ITestOutputHelper output)
     {
+        Plc = new ax_test_projectTwinController(ConnectorAdapterBuilder.Build()
+            .CreateWebApi(Environment.GetEnvironmentVariable("AX_WEBAPI_TARGET"), "Everybody", "", true));
+        Plc.Connector.ReadWriteCycleDelay = 250;
+        Plc.Connector.ExceptionBehaviour = CommExceptionBehaviour.ReThrow;
+        Plc.Connector.SubscriptionMode = ReadSubscriptionMode.Polling;
+        Plc.Connector.BuildAndStart();
+        Plc.Hierarchy.StartPolling(250, this);
+        Task.Delay(1000).Wait();
+        report = output;
+        Plc.Connector.ConcurrentRequestMaxCount = 3;
+        Plc.Connector.ConcurrentRequestDelay = 3;
+        report.WriteLine($"Max requests limit: {Plc.Connector.ConcurrentRequestMaxCount}");
+        report.WriteLine($"Concurrent request delay: {Plc.Connector.ConcurrentRequestDelay}");
+    }
 
-        public void Dispose()
+    public ax_test_projectTwinController Plc { get; private set; }
+
+    public void Dispose()
+    {
+        Plc.Hierarchy.StopPolling(this);
+        Plc = null;
+        GC.Collect();
+    }
+
+    [Fact]
+    public async Task reproductionConsecutiveParalellRead()
+    {
+        //while (true)
         {
-            Plc.Hierarchy.StopPolling( this);
-            Plc = null;
-            System.GC.Collect();
-        }
+            var results = new List<Task>();
 
-        private readonly ITestOutputHelper report;
 
-        public ax_test_projectTwinController Plc { get; private set; }
-
-        private int simultaneousCycles = 10;
-        private int batchCycles = 2;
-
-        public GH_PTKu_ix_xx(ITestOutputHelper output)
-        {
-            Plc = new ax_test_projectTwinController(ConnectorAdapterBuilder.Build().CreateWebApi(Environment.GetEnvironmentVariable("AX_WEBAPI_TARGET"), "Everybody", "", true));
-            Plc.Connector.ReadWriteCycleDelay = 250;
-            Plc.Connector.ExceptionBehaviour = CommExceptionBehaviour.ReThrow;
-            Plc.Connector.SubscriptionMode = ReadSubscriptionMode.Polling;
-            Plc.Connector.BuildAndStart();
-            Plc.Hierarchy.StartPolling(250, this);
-            Task.Delay(1000).Wait();
-            report = output;
-            Plc.Connector.ConcurrentRequestMaxCount = 1;
-            Plc.Connector.ConcurrentRequestDelay = 3;
-            report.WriteLine($"Max requests limit: {Plc.Connector.ConcurrentRequestMaxCount}");
-            report.WriteLine($"Concurrent request delay: {Plc.Connector.ConcurrentRequestDelay}");
-
-        }
-
-        [Fact()]
-        public async Task reproductionConsecutiveParalellRead()
-        {
-
-            //while (true)
+            for (var a = 0; a < batchCycles; a++)
             {
-                var results = new List<Task>();
-                
-
-                
-                  
-                        for (int a = 0; a < batchCycles; a++)
-                        {
-                            results.Add(Plc.maxs.ReadAsync());
-                            results.Add(Plc.mins.ReadAsync());
-                            results.Add(Plc.maxsmatch.ReadAsync());
-                            results.Add(Plc.minsmatch.ReadAsync());
-                            results.Add(Plc.Hierarchy.ReadAsync());
-                        }
-             
-
-               
-
-                foreach (var task in results)
-                {
-                    task.Wait();
-                }
+                results.Add(Plc.maxs.ReadAsync());
+                results.Add(Plc.mins.ReadAsync());
+                results.Add(Plc.maxsmatch.ReadAsync());
+                results.Add(Plc.minsmatch.ReadAsync());
+                results.Add(Plc.Hierarchy.ReadAsync());
             }
 
 
+            foreach (var task in results) task.Wait();
         }
+    }
 
-        [Fact()]
-        public async Task reproductionOverloadRead()
+    [Fact]
+    public async Task reproductionOverloadRead()
+    {
+        //while (true)
         {
-           
-            //while (true)
-            {
-                //System.Threading.Thread.Sleep(1000);
-                var results = new List<Task>();
-                var simulatneous = new List<Task>();
+            //System.Threading.Thread.Sleep(1000);
+            var results = new List<Task>();
+            var simulatneous = new List<Task>();
 
-                for (int i = 0; i < simultaneousCycles; i++)
+            for (var i = 0; i < simultaneousCycles; i++)
+                simulatneous.Add(Task.Run(() =>
                 {
-                    simulatneous.Add(Task.Run(() =>
+                    for (var a = 0; a < batchCycles; a++)
                     {
-                        for (int a = 0; a < batchCycles; a++)
-                        {
-                            results.Add(Plc.maxs.ReadAsync());
-                            results.Add(Plc.mins.ReadAsync());
-                            results.Add(Plc.maxsmatch.ReadAsync());
-                            results.Add(Plc.minsmatch.ReadAsync());
-                            results.Add(Plc.Hierarchy.ReadAsync());
-                        }
-                    }));
-                }
-                
-                foreach (var task in simulatneous)
-                {
-                    task.Wait();
-                    report.WriteLine($"Simultaneous {task.Id}");
-                }
+                        results.Add(Plc.maxs.ReadAsync());
+                        results.Add(Plc.mins.ReadAsync());
+                        results.Add(Plc.maxsmatch.ReadAsync());
+                        results.Add(Plc.minsmatch.ReadAsync());
+                        results.Add(Plc.Hierarchy.ReadAsync());
+                    }
+                }));
 
-                foreach (var task in results)
-                {
-                    task.Wait();
-                    report.WriteLine($"Partial {task.Id}");
-                }
+            foreach (var task in simulatneous)
+            {
+                task.Wait();
+                report.WriteLine($"Simultaneous {task.Id}");
             }
 
-            
-        }
-
-        [Fact()]
-        public async Task reproductionOverloadWrite()
-        {
-
-            //while (true)
+            foreach (var task in results)
             {
-                //System.Threading.Thread.Sleep(1000);
-                var results = new List<Task>();
-                var simulatneous = new List<Task>();
+                task.Wait();
+                report.WriteLine($"Partial {task.Id}");
+            }
+        }
+    }
 
-                for (int i = 0; i < simultaneousCycles; i++)
+    [Fact]
+    public async Task reproductionOverloadWrite()
+    {
+        //while (true)
+        {
+            //System.Threading.Thread.Sleep(1000);
+            var results = new List<Task>();
+            var simulatneous = new List<Task>();
+
+            for (var i = 0; i < simultaneousCycles; i++)
+                simulatneous.Add(Task.Run(() =>
                 {
-                    simulatneous.Add(Task.Run(() =>
+                    for (var a = 0; a < batchCycles; a++)
                     {
-                        for (int a = 0; a < batchCycles; a++)
-                        {
-                            results.Add(Plc.maxs.WriteAsync());
-                            results.Add(Plc.mins.WriteAsync());
-                            results.Add(Plc.maxsmatch.WriteAsync());
-                            results.Add(Plc.minsmatch.WriteAsync());
-                            results.Add(Plc.Hierarchy.WriteAsync());
-                        }
-                    }));
-                }
+                        results.Add(Plc.maxs.WriteAsync());
+                        results.Add(Plc.mins.WriteAsync());
+                        results.Add(Plc.maxsmatch.WriteAsync());
+                        results.Add(Plc.minsmatch.WriteAsync());
+                        results.Add(Plc.Hierarchy.WriteAsync());
+                    }
+                }));
 
-                foreach (var task in simulatneous)
-                {
-                    task.Wait();
-                    report.WriteLine($"Simultaneous {task.Id}");
-                }
-
-                foreach (var task in results)
-                {
-                    task.Wait();
-                    report.WriteLine($"Partial {task.Id}");
-                }
-            }
-        }
-
-        [Fact()]
-        public async Task reproductionConsecutiveParalellWrite()
-        {
-
-            //while (true)
+            foreach (var task in simulatneous)
             {
-
-                var results = new List<Task>();
-                for (int i = 0; i < batchCycles; i++)
-                {
-                    results.Add(Plc.maxs.WriteAsync());
-                    results.Add(Plc.mins.WriteAsync());
-                    results.Add(Plc.maxsmatch.WriteAsync());
-                    results.Add(Plc.minsmatch.WriteAsync());
-                    results.Add(Plc.Hierarchy.WriteAsync());
-                }
-
-                foreach (var task in results)
-                {
-                    task.Wait();
-                }
+                task.Wait();
+                report.WriteLine($"Simultaneous {task.Id}");
             }
 
-
-        }
-
-        [Fact()]
-        public async Task reproductionConsecutiveReadWrite()
-        {
+            foreach (var task in results)
             {
+                task.Wait();
+                report.WriteLine($"Partial {task.Id}");
+            }
+        }
+    }
 
-                var results = new List<Task>();
-                for (int i = 0; i < batchCycles; i++)
-                {
-                    results.Add(Plc.maxs.WriteAsync());
-                    results.Add(Plc.maxs.ReadAsync());
-                    results.Add(Plc.mins.WriteAsync());
-                    results.Add(Plc.mins.ReadAsync());
-                    results.Add(Plc.maxsmatch.WriteAsync());
-                    results.Add(Plc.maxsmatch.ReadAsync());
-                    results.Add(Plc.minsmatch.WriteAsync());
-                    results.Add(Plc.minsmatch.ReadAsync());
-                    results.Add(Plc.Hierarchy.ReadAsync());
-                }
-
-                foreach (var task in results)
-                {
-                    task.Wait();
-                }
+    [Fact]
+    public async Task reproductionConsecutiveParalellWrite()
+    {
+        //while (true)
+        {
+            var results = new List<Task>();
+            for (var i = 0; i < batchCycles; i++)
+            {
+                results.Add(Plc.maxs.WriteAsync());
+                results.Add(Plc.mins.WriteAsync());
+                results.Add(Plc.maxsmatch.WriteAsync());
+                results.Add(Plc.minsmatch.WriteAsync());
+                results.Add(Plc.Hierarchy.WriteAsync());
             }
 
-
+            foreach (var task in results) task.Wait();
         }
+    }
 
-        [Fact()]
-        public async Task reproductionOverloadReadWrite()
+    [Fact]
+    public async Task reproductionConsecutiveReadWrite()
+    {
         {
-            //while (true)
+            var results = new List<Task>();
+            for (var i = 0; i < batchCycles; i++)
             {
-                //System.Threading.Thread.Sleep(1000);
-                var results = new List<Task>();
-                var simulatneous = new List<Task>();
+                results.Add(Plc.maxs.WriteAsync());
+                results.Add(Plc.maxs.ReadAsync());
+                results.Add(Plc.mins.WriteAsync());
+                results.Add(Plc.mins.ReadAsync());
+                results.Add(Plc.maxsmatch.WriteAsync());
+                results.Add(Plc.maxsmatch.ReadAsync());
+                results.Add(Plc.minsmatch.WriteAsync());
+                results.Add(Plc.minsmatch.ReadAsync());
+                results.Add(Plc.Hierarchy.ReadAsync());
+            }
 
-                for (int i = 0; i < simultaneousCycles; i++)
+            foreach (var task in results) task.Wait();
+        }
+    }
+
+    [Fact]
+    public async Task reproductionOverloadReadWrite()
+    {
+        //while (true)
+        {
+            //System.Threading.Thread.Sleep(1000);
+            var results = new List<Task>();
+            var simulatneous = new List<Task>();
+
+            for (var i = 0; i < simultaneousCycles; i++)
+                simulatneous.Add(Task.Run(() =>
                 {
-                    simulatneous.Add(Task.Run(() =>
+                    for (var a = 0; a < batchCycles; a++)
                     {
-                        for (int a = 0; a < batchCycles; a++)
-                        {
-                            results.Add(Plc.maxs.WriteAsync());
-                            results.Add(Plc.maxs.ReadAsync());
-                            results.Add(Plc.mins.WriteAsync());
-                            results.Add(Plc.mins.ReadAsync());
-                            results.Add(Plc.maxsmatch.WriteAsync());
-                            results.Add(Plc.maxsmatch.ReadAsync());
-                            results.Add(Plc.minsmatch.WriteAsync());
-                            results.Add(Plc.minsmatch.ReadAsync());
-                            results.Add(Plc.Hierarchy.ReadAsync());
-                        }
-                    }));
-                }
+                        results.Add(Plc.maxs.WriteAsync());
+                        results.Add(Plc.maxs.ReadAsync());
+                        results.Add(Plc.mins.WriteAsync());
+                        results.Add(Plc.mins.ReadAsync());
+                        results.Add(Plc.maxsmatch.WriteAsync());
+                        results.Add(Plc.maxsmatch.ReadAsync());
+                        results.Add(Plc.minsmatch.WriteAsync());
+                        results.Add(Plc.minsmatch.ReadAsync());
+                        results.Add(Plc.Hierarchy.ReadAsync());
+                    }
+                }));
 
-                foreach (var task in simulatneous)
-                {
-                    task.Wait();
-                    report.WriteLine($"Simultaneous {task.Id}");
-                }
-
-                foreach (var task in results)
-                {
-                    task.Wait();
-                    report.WriteLine($"Partial {task.Id}");
-                }
+            foreach (var task in simulatneous)
+            {
+                task.Wait();
+                var ts = DateTime.Now;
+                report.WriteLine($"Simultaneous {task.Id} | {DateTime.Now}.{ts.Millisecond}");
             }
 
-
+            foreach (var task in results)
+            {
+                task.Wait();
+                var ts = DateTime.Now;
+                report.WriteLine($"Partial {task.Id} | {DateTime.Now}.{ts.Millisecond}");
+            }
         }
     }
 }

--- a/src/AXSharp.sln
+++ b/src/AXSharp.sln
@@ -124,9 +124,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ix_integration_plc", "sanbo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ax_blazor_example", "AXSharp.blazor\tests\sandbox\ax-blazor-example\ix\ax_blazor_example.csproj", "{6605983C-F5BF-4DD5-8F06-640505C0D6B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AXSharp.LocalizablesToResx", "AXSharp.tools\src\AXSharp.LocalizablesToResx\AXSharp.LocalizablesToResx.csproj", "{CC79093E-00B6-42A6-9548-E3A88494DC27}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AXSharp.LocalizablesToResx", "AXSharp.tools\src\AXSharp.LocalizablesToResx\AXSharp.LocalizablesToResx.csproj", "{CC79093E-00B6-42A6-9548-E3A88494DC27}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AXSharp.LocalizablesToResx.Tests", "AXSharp.tools\tests\AXSharp.LocalizablesToResx.Tests\AXSharp.LocalizablesToResx.Tests.csproj", "{4C18C927-8CD6-4ED5-80F1-91DE60D2DD07}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AXSharp.LocalizablesToResx.Tests", "AXSharp.tools\tests\AXSharp.LocalizablesToResx.Tests\AXSharp.LocalizablesToResx.Tests.csproj", "{4C18C927-8CD6-4ED5-80F1-91DE60D2DD07}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This PR addresses various issues with the connector load and stability.
- Single point of entry for reading and writing where throttling is controlled. All request to the Controller over WebAPI is now channeled via a single point.
- Maximum number of concurrent/simultaneous requests is 4 (possibly 5) higher request rate is ignored.
