### PR TITLE
adds option -b for building extended members with $base in symbols

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Compiler.Abstractions/ICompilerOptions.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler.Abstractions/ICompilerOptions.cs
@@ -10,4 +10,5 @@ namespace AXSharp.Compiler;
 public interface ICompilerOptions
 {
     string? OutputProjectFolder { get; set; }
+    bool UseBase { get; set; }
 }

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpConfig.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpConfig.cs
@@ -43,7 +43,9 @@ public class AXSharpConfig : ICompilerOptions
         set => _outputProjectFolder = value;
     }
 
-    
+    public bool UseBase { get; set; }
+
+
     private string _axProjectFolder;
 
     /// <summary>

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
@@ -44,6 +44,7 @@ public class AXSharpProject : IAXSharpProject
         AxProject = axProject;
         CompilerOptions = AXSharpConfig.UpdateAndGetIxConfig(axProject.ProjectFolder, cliCompilerOptions);
         OutputFolder = Path.GetFullPath(Path.Combine(AxProject.ProjectFolder, CompilerOptions.OutputProjectFolder));
+        if (cliCompilerOptions != null) UseBaseSymbol = cliCompilerOptions.UseBase;
         BuilderTypes = builderTypes;
         TargetProject = Activator.CreateInstance(targetProjectType, this) as ITargetProject ?? throw new
             InvalidOperationException("Target project type must implement ITargetProject interface.");
@@ -72,6 +73,8 @@ public class AXSharpProject : IAXSharpProject
     ///     Gets root output folder where the generated sources will be emitted.
     /// </summary>
     public string OutputFolder { get; }
+
+    public bool UseBaseSymbol { get; }
 
     /// <summary>
     ///     Generates outputs from the builders and emits the files into output folder.

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs
@@ -11,6 +11,7 @@ using AX.ST.Semantic;
 using AX.ST.Semantic.Model;
 using AX.ST.Semantic.Model.Declarations;
 using AX.ST.Semantic.Model.Declarations.Types;
+using AX.ST.Syntax.Parser;
 using AXSharp.Compiler.Core;
 using AXSharp.Compiler.Cs.Helpers;
 using AXSharp.Compiler.Cs.Helpers.Onliners;
@@ -138,14 +139,22 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
     }
 
     public static CsOnlinerConstructorBuilder Create(IxNodeVisitor visitor, IClassDeclaration semantics,
-        ISourceBuilder sourceBuilder, bool isExtended)
+        ISourceBuilder sourceBuilder, bool isExtended, AXSharpProject project)
     {
         var builder = new CsOnlinerConstructorBuilder(sourceBuilder);
 
 
         builder.AddToSource(
             $"public {semantics.Name}({typeof(ITwinObject).n()} parent, string readableTail, string symbolTail)");
-        if (isExtended) builder.AddToSource(": base(parent, readableTail, symbolTail)");
+
+
+        if (isExtended)
+        {
+            builder.AddToSource(project.UseBaseSymbol
+                ? ": base(parent, readableTail, symbolTail + \".$base\") "
+                : ": base(parent, readableTail, symbolTail)");
+        }
+
 
         builder.AddToSource("{");
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
@@ -126,7 +126,7 @@ public class CsOnlinerSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
 
         AddToSource(CsOnlinerMemberBuilder.Create(visitor, classDeclaration, this).Output);
 
-        AddToSource(CsOnlinerConstructorBuilder.Create(visitor, classDeclaration, this, isExtended).Output);
+        AddToSource(CsOnlinerConstructorBuilder.Create(visitor, classDeclaration, this, isExtended, this.Project).Output);
 
         AddToSource(CsOnlinerPlainerOnlineToPlainBuilder.Create(visitor, classDeclaration, this, isExtended).Output);
         AddToSource(CsOnlinerPlainerOnlineToPlainProtectedBuilder.Create(visitor, classDeclaration, this, isExtended).Output);

--- a/src/AXSharp.compiler/src/ixc/Options.cs
+++ b/src/AXSharp.compiler/src/ixc/Options.cs
@@ -21,5 +21,9 @@ internal class Options : ICompilerOptions
     [Option('o', "output-project-folder", Required = false,
         HelpText = "Output project folder where compiler emits result. It must be either absolute path or path relative to the Simatic-ax project folder.")]
     public string? OutputProjectFolder { get; set; }
+
+    [Option('b', "use-base-symbol", Required = false, Default = false,
+        HelpText = "Will use base symbol in inherited types")]
+    public bool UseBase { get; set; }
 }
 

--- a/src/AXSharp.compiler/src/ixd/Options.cs
+++ b/src/AXSharp.compiler/src/ixd/Options.cs
@@ -19,6 +19,8 @@ namespace AXSharp.ixc_doc
             HelpText = "Output project folder where compiler emits result.")]
         public string? OutputProjectFolder { get; set; }
 
-
+        [Option('b', "use-base-symbol", Required = false, Default = false,
+            HelpText = "Will use base symbol in inherited types")]
+        public bool UseBase { get; set; }
     }
 }

--- a/src/AXSharp.compiler/src/ixr/Options.cs
+++ b/src/AXSharp.compiler/src/ixr/Options.cs
@@ -18,5 +18,8 @@ namespace AXSharp.ixc_doc
         [Option('o', "output-project-folder", Required = false, HelpText = "Output project folder where compiler emits result.")]
         public string? OutputProjectFolder { get; set; }
 
+        [Option('b', "use-base-symbol", Required = false, Default = false,
+            HelpText = "Will use base symbol in inherited types")]
+        public bool UseBase { get; set; }
     }
 }

--- a/src/AXSharp.compiler/tests/integration/actual/app/AXSharp.config.json
+++ b/src/AXSharp.compiler/tests/integration/actual/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix"}
+{"OutputProjectFolder":"ix","UseBase":false}

--- a/src/AXSharp.compiler/tests/integration/actual/lib1/AXSharp.config.json
+++ b/src/AXSharp.compiler/tests/integration/actual/lib1/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix"}
+{"OutputProjectFolder":"ix","UseBase":false}

--- a/src/AXSharp.compiler/tests/integration/actual/lib2/AXSharp.config.json
+++ b/src/AXSharp.compiler/tests/integration/actual/lib2/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix"}
+{"OutputProjectFolder":"ix","UseBase":false}


### PR DESCRIPTION
In v0.14+ up to v1 (excluded) of sld $base symbol was not included in the name when the type is extended. From v1 this $base was reintroduced. It is expected that the $base will be removed in the future version. However, as a temporary workaround option to ixc was added to include this symbol in case some of the affected versions of sld is used.

will include symbol $base
```
dotnet ixc -b 
``

default remains with no $base symbol.