### PR TITLE
Adds `ignoreSslErrors` to the `WebApiConnector` class

### DIFF
--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
@@ -50,9 +50,11 @@ public class WebApiConnector : Connector
     /// <param name="userName">User name.</param>
     /// <param name="password">Password.</param>
     /// <param name="customServerCertHandler">Customized server certificate handler.</param>
+    /// <param name="ignoreSSLErros">When set to true ssl error are ignored.</param>
     /// <param name="dbName">Root DB name (AX uses 'TGlobalVariablesDB')</param>
     public WebApiConnector(string ipAddress, string userName, string password,
         Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>? customServerCertHandler,
+        bool ignoreSSLErros,
         eTargetProjectPlatform platform = eTargetProjectPlatform.SIMATICAX,
         string dbName = "\"TGlobalVariablesDB\"")
     {
@@ -61,6 +63,10 @@ public class WebApiConnector : Connector
         TargetPlatform = platform;
         UserName = userName;
         UserPassword = password;
+
+        if (ignoreSSLErros)
+            ServerCertificateCallback.CertificateCallback =
+                (sender, cert, chain, sslPolicyErrors) => true;
 
         var serviceFactory = new ApiStandardServiceFactory();
         var client = serviceFactory.GetHttpClient(ipAddress, UserName, UserPassword);

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs
@@ -43,16 +43,18 @@ public static class WebApiConnectorExtensions
     /// <param name="userName">User name.</param>
     /// <param name="password">Password.</param>
     /// <param name="customServerCertHandler">Customized server certificate handler.</param>
+    /// <param name="ignoreSslErrors">When set to true ssl errors are ignored</param>
     /// <param name="dbName">Name of default DB. The DB used to store all data in an AX project is 'TGlobalVariablesDB'.</param>
     /// <returns>Connector adapter for WebAPI connection.</returns>
     public static ConnectorAdapter CreateWebApi(this ConnectorAdapterBuilder adapter,
         string ipAddress, string userName, string password,
         Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>? customServerCertHandler,
+        bool ignoreSslErrors = false,
         eTargetProjectPlatform platform = eTargetProjectPlatform.SIMATICAX,
         string dbName = "\"TGlobalVariablesDB\"")
     {
         return new ConnectorAdapter(typeof(WebApiConnectorFactory))
-        { Parameters = new object[] { ipAddress, userName, password, customServerCertHandler, platform, dbName } };
+        { Parameters = new object[] { ipAddress, userName, password, customServerCertHandler, ignoreSslErrors, platform, dbName } };
     }
 
     public static DateOnly AdjustForLeapDate(this long value)

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorFactory.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorFactory.cs
@@ -32,8 +32,9 @@ public class WebApiConnectorFactory : ConnectorFactory
                 (string)parameters[1],
                 (string)parameters[2],
                 (Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>)parameters[3],
-                (eTargetProjectPlatform)parameters[4],
-                (string)parameters[5]);
+                (bool)parameters[4],
+                (eTargetProjectPlatform)parameters[5],
+                (string)parameters[6]);
         }
     }
 


### PR DESCRIPTION


# Description

The most significant changes involve the addition of a new parameter `ignoreSslErrors` to the `WebApiConnector` class, `CreateWebApi` method, and `WebApiConnectorFactory` class. This parameter allows the user to choose whether to ignore SSL errors or not.

1. The `WebApiConnector` class in `WebApiConnector.cs` has been updated to include a new parameter `ignoreSSLErros` in its constructor. This parameter is a boolean that, when set to true, will ignore SSL errors. If `ignoreSSLErros` is set to true, a lambda function is set to the `CertificateCallback` of `ServerCertificateCallback` that always returns true, effectively ignoring any SSL errors.

2. The `CreateWebApi` method in `WebApiConnectorExtensions.cs` has been updated to include a new parameter `ignoreSslErrors` with a default value of false. The `Parameters` property of the `ConnectorAdapter` object returned by the method has been updated to include `ignoreSslErrors`.

3. The `WebApiConnectorFactory` class in `WebApiConnectorFactory.cs` has been updated to handle the new `ignoreSslErrors` parameter. The `WebApiConnector` object returned by the `Create` method now includes `ignoreSslErrors` as a parameter.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Third party dependency update
- [ ] Third party dependency addition

