### PR TITLE
Various fixes after udpate to stc v6

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
@@ -55,6 +55,11 @@ public class CsOnlinerSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
         AddToSource("using System.Collections.Generic;");
         AddToSource("using AXSharp.Connector.Localizations;");
 
+        foreach (var fileSyntaxUsingDirective in fileSyntax.UsingDirectives)
+        {
+            AddToSource($"using {fileSyntaxUsingDirective.QualifiedIdentifierList.GetText()};");
+        }
+
         fileSyntax.Declarations.ToList().ForEach(p => p.Visit(visitor, this));
     }
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
@@ -179,6 +179,12 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
     public void CreateFile(IFileSyntax fileSyntax, IxNodeVisitor visitor)
     {
         AddToSource("using System;");
+        
+        foreach (var fileSyntaxUsingDirective in fileSyntax.UsingDirectives)
+        {
+            AddToSource($"using Pocos.{fileSyntaxUsingDirective.QualifiedIdentifierList.GetText()};");
+        }
+
         AddToSource("namespace Pocos {");
         fileSyntax.Declarations.ToList().ForEach(p => p.Visit(visitor, this));
         AddToSource("}");

--- a/src/AXSharp.compiler/src/ixr/Program.cs
+++ b/src/AXSharp.compiler/src/ixr/Program.cs
@@ -93,35 +93,35 @@ void Generate(Options o)
 
 void IterateSyntaxTreeForStringLiterals(ISyntaxNode root, LocalizedStringWrapper lw, string fileName)
 {
-    foreach (var literalSyntax in GetChildNodesRecursive(root).OfType<ILiteralSyntax>())
-    {
-        var token = literalSyntax.Tokens.First();
-        //literalSyntax.Location
-        AddToDictionaryIfLocalizedString(token,lw,fileName);
-    }
+    //foreach (var literalSyntax in GetChildNodesRecursive(root).OfType<ILiteralSyntax>())
+    //{
+    //    var token = literalSyntax.Tokens.First();
+    //    //literalSyntax.Location
+    //    AddToDictionaryIfLocalizedString(token,lw,fileName);
+    //}
 }
 
 
 
 void IterateSyntaxTreeForPragmas(ISyntaxNode root, LocalizedStringWrapper lw, string fileName)
 {
-    //foreach (var pragmaSyntax in GetChildNodesRecursive(root).OfType<PragmaSyntax>())
-    //{
-    //    var token = pragmaSyntax.PragmaToken;
-    //    if(lw.IsAttributeNamePragmaToken(token.Text))
-    //    { 
-    //        AddToDictionaryIfLocalizedString(token,lw,fileName);
-    //    }
-    //}
+    foreach (var pragmaSyntax in GetChildNodesRecursive(root).OfType<PragmaSyntax>())
+    {
+        var token = pragmaSyntax;
+        if (lw.IsAttributeNamePragmaToken(token.PragmaContent))
+        {
+            AddToDictionaryIfLocalizedString(token, lw, fileName);
+        }
+    }
 }
 
-void AddToDictionaryIfLocalizedString(ISyntaxToken token, LocalizedStringWrapper lw, string fileName)
+void AddToDictionaryIfLocalizedString(PragmaSyntax token, LocalizedStringWrapper lw, string fileName)
 {
     // if is valid token
     if(IsStringToken(token) || IsPragmaToken(token))
     {
         // try to acquire localized string
-        var localizedStringList = lw.TryToGetLocalizedStrings(token.Text);
+        var localizedStringList = lw.TryToGetLocalizedStrings(token.PragmaContent);
 
         if(localizedStringList == null) 
         {
@@ -139,7 +139,7 @@ void AddToDictionaryIfLocalizedString(ISyntaxToken token, LocalizedStringWrapper
             //check if identifier is valid
             if(lw.IsValidId(id))
             { 
-                var pos = token.Location.GetLineSpan().StartLinePosition;
+                var pos = token.SourceText.GetLineSpan(token.Span).StartLinePosition;
                 var wrapper = new StringValueWrapper(rawText, fileName, pos.Line);
                 // add id and wrapper to dictionary
                 lw.LocalizedStringsDictionary.TryAdd(id, wrapper);
@@ -147,7 +147,7 @@ void AddToDictionaryIfLocalizedString(ISyntaxToken token, LocalizedStringWrapper
         }   
     }
 }
-bool IsPragmaToken(ISyntaxToken token)
+bool IsPragmaToken(PragmaSyntax token)
 { 
     //if(token.SyntaxKind == SyntaxKind.PragmaToken) 
     //{ 
@@ -156,7 +156,7 @@ bool IsPragmaToken(ISyntaxToken token)
     return false; 
 }
 
-bool IsStringToken(ISyntaxToken token)
+bool IsStringToken(PragmaSyntax token)
 { 
     if(token.SyntaxKind == SyntaxKind.TypedStringDToken ||
         token.SyntaxKind == SyntaxKind.TypedStringSToken ||

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/Onliners/class_extended_by_known_type.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/Onliners/class_extended_by_known_type.g.cs
@@ -3,6 +3,8 @@ using AXSharp.Connector;
 using AXSharp.Connector.ValueTypes;
 using System.Collections.Generic;
 using AXSharp.Connector.Localizations;
+using Simatic.Ax.Stateframework;
+using Simatic.Ax.StatePattern;
 
 namespace Simatic.Ax.StateFramework
 {

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/Onliners/file_with_usings.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/Onliners/file_with_usings.g.cs
@@ -3,6 +3,9 @@ using AXSharp.Connector;
 using AXSharp.Connector.ValueTypes;
 using System.Collections.Generic;
 using AXSharp.Connector.Localizations;
+using FileWithUsingsSimpleFirstLevelNamespace;
+using FileWithUsingsSimpleQualifiedNamespace.Qualified;
+using FileWithUsingsHelloLevelOne.FileWithUsingsHelloLevelTwo;
 
 namespace FileWithUsingsSimpleFirstLevelNamespace
 {

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/POCO/class_extended_by_known_type.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/POCO/class_extended_by_known_type.g.cs
@@ -1,4 +1,6 @@
 using System;
+using Pocos.Simatic.Ax.Stateframework;
+using Pocos.Simatic.Ax.StatePattern;
 
 namespace Pocos
 {

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/POCO/file_with_usings.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/.g/POCO/file_with_usings.g.cs
@@ -1,4 +1,7 @@
 using System;
+using Pocos.FileWithUsingsSimpleFirstLevelNamespace;
+using Pocos.FileWithUsingsSimpleQualifiedNamespace.Qualified;
+using Pocos.FileWithUsingsHelloLevelOne.FileWithUsingsHelloLevelTwo;
 
 namespace Pocos
 {


### PR DESCRIPTION


1. The `IterateSyntaxTreeForStringLiterals` method has been commented out, disabling its execution.
1. The `IterateSyntaxTreeForPragmas` method has been uncommented and modified. The `token` variable now refers to `pragmaSyntax` and the `IsAttributeNamePragmaToken` method checks the `PragmaContent` of the `token`.
1. The `AddToDictionaryIfLocalizedString` method's parameter type has been changed from `ISyntaxToken` to `PragmaSyntax`. The `TryToGetLocalizedStrings` method now checks the `PragmaContent` of the `token`.
1. The `pos` variable in the `AddToDictionaryIfLocalizedString` method now gets its value from `token.SourceText.GetLineSpan(token.Span).StartLinePosition`.
1. The `IsPragmaToken` and `IsStringToken` methods' parameter type has been changed from `ISyntaxToken` to `PragmaSyntax`. The check for `SyntaxKind.PragmaToken` in `IsPragmaToken` has been commented out.
1. The `IsStringToken` method now checks if the `SyntaxKind` of the `token` is `TypedStringDToken`, `TypedStringSToken`, `UntypedStringDToken`, or `UntypedStringSToken`.
1. The `CsOnlinerSourceBuilder` and `CsPlainSourceBuilder` classes have been updated to include a foreach loop that iterates over the `UsingDirectives` of the `fileSyntax` object. This loop adds each `UsingDirective` to the source code with the appropriate namespace. The `CsOnlinerSourceBuilder` adds the namespace as is, while the `CsPlainSourceBuilder` prepends "Pocos." to the namespace.
1. The `class_extended_by_known_type.g.cs` and `file_with_usings.g.cs` files have been updated to include additional `using` directives. These directives import namespaces related to the `Simatic.Ax.Stateframework`, `Simatic.Ax.StatePattern`, and various `FileWithUsings` namespaces.
1. The `class_extended_by_known_type.g.cs` and `file_with_usings.g.cs` files have also been updated to include additional `using` directives under the `Pocos` namespace. These directives import the same namespaces as above, but under the `Pocos` namespace.