### PR TITLE
updates vulnerable depencencies, removes some warnigs from CI/CD build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,13 +31,16 @@
     <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.IO.Packaging" Version="9.0.0" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="YamlDotNet" Version="16.2.0" />
     <PackageVersion Include="bunit" Version="1.36.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="ResXResourceReader.NetStandard" Version="1.3.0" />    
+    <PackageVersion Include="ResXResourceReader.NetStandard" Version="1.3.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="gh-packages-ix-ax" value="https://nuget.pkg.github.com/ix-ax/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  
+  <packageSourceMapping>
+    <!-- Get AXSharp.* & AXOpen packages from ax -->
+    <packageSource key="gh-packages-ix-ax">
+      <package pattern="AXSharp.*"/>
+      <package pattern="AXOpen.*"/>
+    </packageSource>
+    
+    <!-- Get all other packages from nuget.org -->
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -83,6 +83,12 @@ public sealed class ProvisionTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
+        context.DotNetBuildSettings.MSBuildSettings.Properties.Add("NoWarn", new List<string>() 
+            { "1234;2345;8602;10012;8618;0162;8605;1416;3270;1504;8600;8618;" +
+                "CS0618;CS1591;BL0007;BL0005;CA1416;CA2200;CS0105;CS0108;CS0109;CS0162;CS0168;CS0169;CS219;CS0414;CS0436;CS0472;CS0618;CS1591;CS1998;CS8604;" +
+                "CS8601;SYSLIB0051;SYSLIB0014;CS8625;CS0219;CS8625;CS8625;CS8620;RZ2012;RZ10012;CS4014;CS8981;CS8603;CS8766;CS8619;CS0649;CS8321"
+            });
+            
         ProvisionProjectWideTools(context);
     }
 
@@ -119,6 +125,7 @@ public sealed class BuildTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
+          
         context.DotNetBuild(Path.Combine(context.ScrDir, "AXSharp.compiler\\src\\ixc\\AXSharp.ixc.csproj"), context.DotNetBuildSettings);
 
         var axprojects = new List<string>()
@@ -137,6 +144,7 @@ public sealed class BuildTask : FrostingTask<BuildContext>
         foreach (var axproject in axprojects)
         {
             context.DotNetRunSettings.WorkingDirectory = Path.Combine(context.ScrDir, axproject);
+          
             context.DotNetRun(Path.Combine(context.ScrDir, "AXSharp.compiler\\src\\ixc\\AXSharp.ixc.csproj"), context.DotNetRunSettings);
         }
 

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/AXSharp.Presentation.Blazor.Controls.csproj
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/AXSharp.Presentation.Blazor.Controls.csproj
@@ -82,7 +82,10 @@
   </ItemGroup>
 
   <ItemGroup>  
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />  
+    <PackageReference Include="System.Net.Http" />  
+    <PackageReference Include="System.Text.Encodings.Web" />  
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor/AXSharp.Presentation.Blazor.csproj
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor/AXSharp.Presentation.Blazor.csproj
@@ -60,8 +60,11 @@
   </ItemGroup>
 
   <ItemGroup>   
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AXSharp.blazor/tests/sandbox/AXSharp.RenderableContent.Tests/AXSharp.RenderableContent.Tests.csproj
+++ b/src/AXSharp.blazor/tests/sandbox/AXSharp.RenderableContent.Tests/AXSharp.RenderableContent.Tests.csproj
@@ -7,9 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="bunit"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit"/>
+	  <PackageReference Include="bunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.RegularExpressions" />
+    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/ComponentsExamples.csproj
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/ComponentsExamples.csproj
@@ -12,7 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AXSharp.blazor/tests/sandbox/IxBlazor.App/IxBlazor.App.csproj
+++ b/src/AXSharp.blazor/tests/sandbox/IxBlazor.App/IxBlazor.App.csproj
@@ -11,6 +11,12 @@
     <_ContentIncludedByDefault Remove="wwwroot\css\bootstrap\bootstrap.css.map" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.RegularExpressions" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\AXSharp.Presentation.Blazor.Controls\AXSharp.Presentation.Blazor.Controls.csproj" />

--- a/src/AXSharp.tools/tests/AXSharp.nuget.update.Tests/AXSharp.nuget.update.Tests.csproj
+++ b/src/AXSharp.tools/tests/AXSharp.nuget.update.Tests/AXSharp.nuget.update.Tests.csproj
@@ -6,16 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture"/>
-    <PackageReference Include="AutoFixture.AutoNSubstitute"/>
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="NSubstitute"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Text.RegularExpressions" />
+    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/sanbox/integration/ix-integration-blazor/ix-integration-blazor.csproj
+++ b/src/sanbox/integration/ix-integration-blazor/ix-integration-blazor.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Interactive"/>
+		<PackageReference Include="System.Interactive" />
+		<PackageReference Include="System.Text.Encodings.Web" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/sanbox/integration/ix-integration-library/ix-integration-library.csproj
+++ b/src/sanbox/integration/ix-integration-library/ix-integration-library.csproj
@@ -13,7 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web"/>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/configuration.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/configuration.g.cs
@@ -20,11 +20,9 @@ namespace Pocos
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Weather in a tabs and grouped in group box")]
         public Layouts.Tabbed.weather weather_tabbed { get; set; } = new Layouts.Tabbed.weather();
 
-        [ReadOnce()]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Weather structure set to read once")]
         public Layouts.Stacked.weather weather_readOnce { get; set; } = new Layouts.Stacked.weather();
 
-        [ReadOnly()]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Weather structure set to read only")]
         public Layouts.Stacked.weather weather_readOnly { get; set; } = new Layouts.Stacked.weather();
         public example test_example { get; set; } = new example();

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/example.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/example.g.cs
@@ -10,44 +10,20 @@ namespace Pocos
         {
         }
 
-        [Container(Layout.Stack)]
         public test_primitive primitives_stack { get; set; } = new test_primitive();
-
-        [Container(Layout.Wrap)]
         public test_primitive primitives_wrap { get; set; } = new test_primitive();
-
-        [Container(Layout.Tabs)]
         public test_primitive primitives_tabs { get; set; } = new test_primitive();
-
-        [Container(Layout.UniformGrid)]
         public test_primitive primitives_uniform { get; set; } = new test_primitive();
-
-        [Container(Layout.Stack)]
-        [Group(GroupLayout.GroupBox)]
         public test_primitive test_groupbox { get; set; } = new test_primitive();
-
-        [Container(Layout.Stack)]
-        [Group(GroupLayout.Border)]
         public test_primitive test_border { get; set; } = new test_primitive();
-
-        [Container(Layout.Tabs)]
-        [Group(GroupLayout.GroupBox)]
         public groupbox testgroupbox { get; set; } = new groupbox();
         public border testborder { get; set; } = new border();
         public ixcomponent ixcomponent_instance { get; set; } = new ixcomponent();
         public MySecondNamespace.ixcomponent ixcomponent_instance2 { get; set; } = new MySecondNamespace.ixcomponent();
         public ThirdNamespace.ixcomponent ixcomponent_instance3 { get; set; } = new ThirdNamespace.ixcomponent();
-
-        [Container(Layout.Stack)]
         public compositeLayout compositeStack { get; set; } = new compositeLayout();
-
-        [Container(Layout.Wrap)]
         public compositeLayout compositeWrap { get; set; } = new compositeLayout();
-
-        [Container(Layout.UniformGrid)]
         public compositeLayout compositeUniform { get; set; } = new compositeLayout();
-
-        [Container(Layout.Tabs)]
         public compositeLayout compositeTabs { get; set; } = new compositeLayout();
     }
 }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/measurement.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/measurement.g.cs
@@ -15,7 +15,6 @@ namespace Pocos
             [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Minimum")]
             public Single Min { get; set; }
 
-            [ReadOnly()]
             [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Measured")]
             public Single Acquired { get; set; }
 
@@ -32,23 +31,15 @@ namespace Pocos
             {
             }
 
-            [Container(Layout.Stack)]
-            [Group(GroupLayout.GroupBox)]
             [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Stack panel")]
             public MeasurementExample.Measurement measurement_stack { get; set; } = new MeasurementExample.Measurement();
 
-            [Container(Layout.Wrap)]
-            [Group(GroupLayout.GroupBox)]
             [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Wrap panel")]
             public MeasurementExample.Measurement measurement_wrap { get; set; } = new MeasurementExample.Measurement();
 
-            [Container(Layout.UniformGrid)]
-            [Group(GroupLayout.GroupBox)]
             [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Grid")]
             public MeasurementExample.Measurement measurement_grid { get; set; } = new MeasurementExample.Measurement();
 
-            [Container(Layout.Tabs)]
-            [Group(GroupLayout.GroupBox)]
             [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Tabs")]
             public MeasurementExample.Measurement measurement_tabs { get; set; } = new MeasurementExample.Measurement();
         }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/weatherBase.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/weatherBase.g.cs
@@ -14,31 +14,23 @@ namespace Pocos
         public Single Longitude { get; set; }
         public Single Altitude { get; set; }
         public string Description { get; set; } = string.Empty;
-
-        [ReadOnly()]
         public string LongDescription { get; set; } = string.Empty;
 
-        [ReadOnce()]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "this has [ReadOnce()] attribute will be readon only once...")]
         public Int16 StartCounter { get; set; }
 
-        [RenderIgnore()]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore()] must not be displayed!")]
         public string RenderIgnoreAllToghether { get; set; } = string.Empty;
 
-        [RenderIgnore("Control")]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Control'')]")]
         public string RenderIgnoreWhenControl { get; set; } = string.Empty;
 
-        [RenderIgnore("Display")]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Display'')]")]
         public string RenderIgnoreWhenDisplay { get; set; } = string.Empty;
 
-        [RenderIgnore("Control", "ShadowControl")]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Control'', ''ShadowControl'')]")]
         public string RenderIgnoreWhenControlAndShadow { get; set; } = string.Empty;
 
-        [RenderIgnore("Display", "ShadowDisplay")]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Display'', ''ShadowDisplay'')]")]
         public string RenderIgnoreWhenDisplayAndShadow { get; set; } = string.Empty;
     }

--- a/src/tests.integrations/integrated/src/integrated.twin/.g/POCO/dataswapping/moster.g.cs
+++ b/src/tests.integrations/integrated/src/integrated.twin/.g/POCO/dataswapping/moster.g.cs
@@ -19,11 +19,7 @@ namespace Pocos
             public UInt64 Id { get; set; }
             public Byte[] ArrayOfBytes { get; set; } = new Byte[4];
             public MonsterData.DriveBase[] ArrayOfDrives { get; set; } = new MonsterData.DriveBase[4];
-
-            [IgnoreOnPocoOperation()]
             public MonsterData.DriveBase DriveBase_tobeignoredbypocooperations { get; set; } = new MonsterData.DriveBase();
-
-            [IgnoreOnPocoOperation()]
             public string Description_tobeignoredbypocooperations { get; set; } = string.Empty;
         }
 


### PR DESCRIPTION
This pull request includes several changes to update package references, modify build settings, and clean up attributes in generated POCO files. The most important changes are grouped below by theme.

### Package Updates:
* Added multiple package references in `Directory.Packages.props` and various `.csproj` files to include `System.Net.Http`, `System.Text.Encodings.Web`, and `System.Text.RegularExpressions`. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R34-R37) [[2]](diffhunk://#diff-5e09615a57027ddf08606b71f0cfbbae4afc29ca2ff7cd381e242d8c0cd6731eR86-R88) [[3]](diffhunk://#diff-ea6505fd31c080135df3b1199da395a10fb97b023fb799c3b1dfd11a14402c76R65-R67) [[4]](diffhunk://#diff-297329a95834354f3b83fd04c84aed21253de47ad0e1579fb0c08d19ab61ac35R12-R14) [[5]](diffhunk://#diff-398949f26f4f8fc0159a5ca37579eaee8f7660d3f9651e0c2c19d96b2796995dR16-R18) [[6]](diffhunk://#diff-053987124c3eefd72d236d5ff935f890bc8a729d42306b745b65afddc3b13a60R14-R19) [[7]](diffhunk://#diff-45baafdba08606d12e26cca09f43635d75eea6a66921b0de498aed312172ca48R18-R19) [[8]](diffhunk://#diff-2c9acebbf4f4456bc0f083f5af167ce7fe3ef24ddd79113feb676612d9ed2e86R12) [[9]](diffhunk://#diff-b40b6af6d114348de23d416629a648879bb6394e589b07eab246ef38c8bfc66cR17)

### Build Configuration:
* Added a new `NuGet.config` file to configure package sources and package source mapping.
* Updated `ProvisionTask` in `cake/Program.cs` to add a list of warnings to ignore in `DotNetBuildSettings`.

### Code Cleanup:
* Removed various attributes such as `[ReadOnce()]`, `[ReadOnly()]`, `[Container]`, `[Group]`, and `[RenderIgnore()]` from generated POCO files to simplify the code. [[1]](diffhunk://#diff-59456263f4add3237ff7ad6d3721aeb96621fc8add2cbd1315ce0752be535d7eL23-L27) [[2]](diffhunk://#diff-f5970a813ea61125da4f68a740186e2c45cb2499ca4c3f1c5bd0581f828c73fbL13-L50) [[3]](diffhunk://#diff-0b91dd8da1b59b8dfe8bcde8a4cf05a5a186e8adcb35b4a74227dd763ba549a2L18) [[4]](diffhunk://#diff-0b91dd8da1b59b8dfe8bcde8a4cf05a5a186e8adcb35b4a74227dd763ba549a2L35-L51) [[5]](diffhunk://#diff-96948c4469948bdfade497aa152767d70040c53242936076bf5ca043408602a8L17-L41) [[6]](diffhunk://#diff-8e8b48e7921107e58fa7b81f1de24a273a26c50b1c7517579ad269f99c076555L22-L26)