### PR TITLE
adds .net8 due to compatibility issues on an existing project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
  <PropertyGroup>
-   <TargetFrameworks>net9.0</TargetFrameworks>  
+   <TargetFrameworks>net9.0;net8.0</TargetFrameworks>  
     <!-- Define output directories based on project names 
     <OutputPath>$(MSBuildThisFileDirectory)\.builds\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(MSBuildThisFileDirectory)\.builds\obj\$(MSBuildProjectName)\$(Configuration)\</IntermediateOutputPath>  -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,31 +9,52 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </GlobalPackageReference>
+
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />    
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="System.IO.Packaging" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />    
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />    
+    <PackageVersion Include="System.Speech" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />    
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" Condition="'$(TargetFramework)' == 'net8.0'" />    
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="System.IO.Packaging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />    
+    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0'" />    
+    <PackageVersion Include="System.Speech" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />    
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
     <PackageVersion Include="Cake.DocFx" Version="1.0.0" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Octokit.Extensions" Version="1.0.7" />
     <PackageVersion Include="Cake.Frosting" Version="5.0.0" />
     <PackageVersion Include="Cake.Powershell" Version="4.0.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.28.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
     <PackageVersion Include="CliWrap" Version="3.6.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="NuGet.Configuration" Version="6.12.1" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
     <PackageVersion Include="Polly" Version="8.5.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />  
     <PackageVersion Include="Irony" Version="1.5.3" />
     <PackageVersion Include="Irony.Interpreter" Version="1.5.3" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="System.IO.Packaging" Version="9.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="YamlDotNet" Version="16.2.0" />
     <PackageVersion Include="bunit" Version="1.36.0" />
@@ -55,12 +76,6 @@
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="System.Speech" Version="9.0.0" />
-    <PackageVersion Include="System.Interactive" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
+    <PackageVersion Include="System.Interactive" Version="6.0.1" />    
   </ItemGroup>
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 0.21.0
+next-version: 0.22.0
 branches:
   main:
     regex: ^master$|^main$

--- a/cake/Build.csproj
+++ b/cake/Build.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <OutputType>Exe</OutputType>    
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
 	  <IsPackable>false</IsPackable>

--- a/cake/BuildContext.cs
+++ b/cake/BuildContext.cs
@@ -178,7 +178,7 @@ public class BuildContext : FrostingContext
         }
     }
 
-    public IEnumerable<string> TargetFrameworks { get; } = new List<string>() { "net9.0" };
+    public IEnumerable<string> TargetFrameworks { get; } = new List<string>() { "net9.0", "net8.0" };
 
     public IEnumerable<(string ax, string approject, string solution)> GetTemplateProjects()
     {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/CsProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/CsProject.cs
@@ -123,7 +123,7 @@ public class CsProject : ITargetProject
             var defaultCsProjectWhenNotProvidedByTemplate =
                 $@"<Project Sdk=""Microsoft.NET.Sdk"">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/units.csproj
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/units.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+	<PropertyGroup>		
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/templates/working/AXSharp.templates.csproj
+++ b/templates/working/AXSharp.templates.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0;net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <PackageType>Template</PackageType>
     <PackageId>AXSharp.templates</PackageId>
     <Title>AXSharp templates</Title>

--- a/templates/working/AXSharp.templates.csproj
+++ b/templates/working/AXSharp.templates.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0;net8.0</TargetFramework>
     <PackageType>Template</PackageType>
     <PackageId>AXSharp.templates</PackageId>
     <Title>AXSharp templates</Title>

--- a/templates/working/templates/axsharpblazor/axsharpblazor.twin/axsharpblazor.csproj
+++ b/templates/working/templates/axsharpblazor/axsharpblazor.twin/axsharpblazor.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/templates/working/templates/axsharpblazor/axsharpblazor.twin/axsharpblazor.twin.csproj
+++ b/templates/working/templates/axsharpblazor/axsharpblazor.twin/axsharpblazor.twin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/templates/working/templates/axsharpconsole/axsharpconsole.twin/axsharpconsole.csproj
+++ b/templates/working/templates/axsharpconsole/axsharpconsole.twin/axsharpconsole.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/templates/working/templates/axsharpconsole/axsharpconsole/axsharpconsole.app.csproj
+++ b/templates/working/templates/axsharpconsole/axsharpconsole/axsharpconsole.app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0;net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/templates/working/templates/axsharpconsole/axsharpconsole/axsharpconsole.app.csproj
+++ b/templates/working/templates/axsharpconsole/axsharpconsole/axsharpconsole.app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0;net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This pull request includes updates to support multiple target frameworks and adds specific package versions for each framework. The changes ensure compatibility with both .NET 9.0 and .NET 8.0.

### Target Framework Updates:
* Updated `TargetFrameworks` to include both `net9.0` and `net8.0` in several project files to support multiple target frameworks. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL3-R3) [[2]](diffhunk://#diff-16c12c10ba0738608f9aaa1920089e90ea692659bfbe06e24bd07616fbeccd64R3) [[3]](diffhunk://#diff-303674f613c0cb1cf087783a14562e47a47c39e3432afa2f90723389261ec647L126-R126) [[4]](diffhunk://#diff-76f30b2be2bc68c7761a4b8c5828af62a3b7627ad9abf5cbcfc2c523257137c6L3-R3) [[5]](diffhunk://#diff-75cc7b26138dd45810e429d8e3a61e147eec637c19a97871984570d4fcd9a4f9L3-R3) [[6]](diffhunk://#diff-c3def61e55be9d6ee0f71b398727de72900562288e4ab2c94caf0d807325fc9bL3-R3) [[7]](diffhunk://#diff-9044bb39ea3902c150e1b9e129458b7bfef5bc054600041cf7db10c0bdfe8f99L4-R4)

### Package Version Updates:
* Added specific package versions for `net9.0` and `net8.0` in `Directory.Packages.props` to ensure compatibility with each framework. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R12-L36) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L58-L64)

### Codebase Changes:
* Updated the `TargetFrameworks` property in `BuildContext.cs` to include both `net9.0` and `net8.0`.
* Removed redundant package versions in `Directory.Packages.props` to clean up the file.