### PR TITLE
[BUG] Days in leap year are not correctly retrieved from the controller

### DIFF
--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs
@@ -106,7 +106,7 @@ public class WebApiDate : OnlinerDate, IWebApiPrimitive
 
             case eTargetProjectPlatform.SIMATICAX:
                 var valAx = value / 100;
-                return valAx.AdjustForLeapDate();
+                return valAx.GetDateOnly();
             
             default:
                 var valdef = value / 100;

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDateTime.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDateTime.cs
@@ -138,7 +138,7 @@ public class WebApiDateTime : OnlinerDateTime, IWebApiPrimitive
     private DateTime GetFromBinary(long val)
     {
         var dt = val / 100;
-        return dt.AdjustForLeapDateTime(); // DateTime.FromBinary(dt).AddYears(1969);
+        return dt.ToUtcDateTime(); // DateTime.FromBinary(dt).AddYears(1969);
     }
 
     private string GetFromDate(DateTime dateTime)

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDate.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDate.cs
@@ -84,7 +84,7 @@ public class WebApiLDate : OnlinerDate, IWebApiPrimitive
     private DateOnly GetFromBinary(long value)
     {
         var val = value / 100;
-        return val.AdjustForLeapDate(); // DateOnly.FromDateTime(DateTime.FromBinary(val).AddYears(1969));
+        return val.GetDateOnly(); // DateOnly.FromDateTime(DateTime.FromBinary(val).AddYears(1969));
     }
 
     private string GetFromDate(DateOnly date)

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDateTime.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDateTime.cs
@@ -84,7 +84,7 @@ public class WebApiLDateTime : OnlinerLDateTime, IWebApiPrimitive
     private DateTime GetFromBinary(long val)
     {
         var dt = val / 100;
-        return dt.AdjustForLeapDateTime(); // DateTime.FromBinary(dt).AddYears(1969);
+        return dt.ToUtcDateTime(); // DateTime.FromBinary(dt).AddYears(1969);
     }
 
 

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs
@@ -57,17 +57,19 @@ public static class WebApiConnectorExtensions
         { Parameters = new object[] { ipAddress, userName, password, customServerCertHandler, ignoreSslErrors, platform, dbName } };
     }
 
-    public static DateOnly AdjustForLeapDate(this long value)
-    {        
-        var noLeap = DateOnly.FromDateTime(DateTime.FromBinary(value).AddYears(1969));
-        var leapDays = DateTime.IsLeapYear(noLeap.Year) && ((noLeap.Month == 2 && noLeap.Day == 29) || noLeap.Month >= 3) ? -1 : 0;
-        return noLeap.AddDays(leapDays);
+    public static DateOnly GetDateOnly(this long value)
+    {
+        // 1 tick = 100 ns
+        // Use DateTimeKind.Utc for correct interpretation
+        var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                           .AddTicks(value);
+
+        // Return the date portion in UTC
+        return DateOnly.FromDateTime(dateTime.ToUniversalTime());
     }
 
-    public static DateTime AdjustForLeapDateTime(this long value)
+    public static DateTime ToUtcDateTime(this long value)
     {
-        var noLeap = DateTime.FromBinary(value).AddYears(1969);
-        var leapDays = DateTime.IsLeapYear(noLeap.Year) && ((noLeap.Month == 2 && noLeap.Day == 29) || noLeap.Month >= 3) ? -1 : 0;
-        return noLeap.AddDays(leapDays);
+        return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(value);
     }
 }

--- a/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiPrimitiveTests.cs
+++ b/src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiPrimitiveTests.cs
@@ -186,8 +186,8 @@ namespace AXSharp.Connector.S71500.WebAPITests.Primitives
         [Fact]
         public virtual async void should_synchron_write_leap_value_check_leap()
         {
-            var testDate = new DateOnly(2025, 1, 1);
-            for (int i = 0; i < 100; i++)
+            var testDate = new DateOnly(2024, 1, 1);
+            for (int i = 0; i < 365*5; i++)
             {
                 testDate = testDate.AddDays(1);
                 TestConnector.TestApiConnector.ClearPeriodicReadSet();
@@ -195,7 +195,7 @@ namespace AXSharp.Connector.S71500.WebAPITests.Primitives
                 var actual = await webApiPrimitive.GetAsync();
                 if(testDate != actual)
                     Output.WriteLine($"Expected: {testDate} - Actual: {actual} {testDate == actual}"); 
-               // Assert.Equal(testDate, actual);
+                Assert.Equal(testDate, actual);
             }            
         }
 

--- a/src/AXSharp.connectors/tests/ax-test-project/ax-test-project.sln
+++ b/src/AXSharp.connectors/tests/ax-test-project/ax-test-project.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ax_test_project", "ix\ax_test_project.csproj", "{C821E27A-DD87-A1A7-0B15-842E89FDA2A2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C821E27A-DD87-A1A7-0B15-842E89FDA2A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C821E27A-DD87-A1A7-0B15-842E89FDA2A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C821E27A-DD87-A1A7-0B15-842E89FDA2A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C821E27A-DD87-A1A7-0B15-842E89FDA2A2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {550C4796-5273-4560-BB73-CED0252EDF8C}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This pull request includes several changes to the `AXSharp.Connector.S71500.WebAPI` project, primarily focused on updating date and time handling methods and improving test coverage.

### Date and Time Handling Updates:
* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs`](diffhunk://#diff-23455ce2ea78aaeba5ba88bfb15881ea5e8e5072dfc4d379006944f5262ec998L109-R109): Replaced `AdjustForLeapDate` with `GetDateOnly` in the `GetFromBinary` method.
* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDateTime.cs`](diffhunk://#diff-9d03d18d0a5a45e41fe09c4ecd0af2d9a1e30c8ef949d95b7417bc11217ea4b9L141-R141): Replaced `AdjustForLeapDateTime` with `ToUtcDateTime` in the `GetFromBinary` method.
* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDate.cs`](diffhunk://#diff-700b061cb080ff37046369cfc0e35e007ceedefb83e05009b8667df124ebafabL87-R87): Replaced `AdjustForLeapDate` with `GetDateOnly` in the `GetFromBinary` method.
* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiLDateTime.cs`](diffhunk://#diff-a1cb9ae65d76555525daf063e88cd873a5efbd8f918261b6b3e224c07689e212L87-R87): Replaced `AdjustForLeapDateTime` with `ToUtcDateTime` in the `GetFromBinary` method.
* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs`](diffhunk://#diff-65e3da4d8fc57ca29a968f2f7b2ae35ff5c4123bf213055cd4443b7f7eed7d49L60-R73): Updated `AdjustForLeapDate` to `GetDateOnly` and `AdjustForLeapDateTime` to `ToUtcDateTime`.

### Test Coverage Improvements:
* [`src/AXSharp.connectors/tests/AXSharp.Connector.Sax.WebAPITests/WebApiConnector/WebApiPrimitiveTests.cs`](diffhunk://#diff-75e527ed7a8ecf5c81b24a075f92694306968b39e3bc60e7ad1e604d3baa124bL189-R198): Modified the leap year test to increase the test range and added an assertion for validation.

### Project Configuration:
* [`src/AXSharp.connectors/tests/ax-test-project/ax-test-project.sln`](diffhunk://#diff-a1becfc30a53325483115676e559e6dc0786a1747f3d6bae701eb0aa231f4234R1-R24): Added a new Visual Studio solution file for the `ax_test_project`.
closes #203