### PR TITLE
When compiling dependencies of larger project the tpf is null

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpConfig.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpConfig.cs
@@ -81,7 +81,7 @@ public class AXSharpConfig : ICompilerOptions
     /// <param name="directory">AX project directory</param>
     /// <param name="newCompilerOptions">Compiler options.</param>
     /// <returns>Ix configuration for given AX project.</returns>
-    public static AXSharpConfig UpdateAndGetAXSharpConfig(string directory, ICompilerOptions? newCompilerOptions = null)
+    public static AXSharpConfig UpdateAndGetAXSharpConfig(string directory, ICompilerOptions? newCompilerOptions = null, ICompilerOptions dependnantCompilerOptions = null)
     {
         var ixConfigFilePath = Path.Combine(directory, CONFIG_FILE_NAME);
 
@@ -99,6 +99,11 @@ public class AXSharpConfig : ICompilerOptions
         {
             AXSharpConfig.AxProjectFolder = directory;
             OverridesFromCli(AXSharpConfig, newCompilerOptions);
+
+            if (dependnantCompilerOptions != null)
+            {
+                AXSharpConfig.TargetPlatfromMoniker = dependnantCompilerOptions.TargetPlatfromMoniker;
+            }            
         }
 
         using (StreamWriter file = File.CreateText(ixConfigFilePath))
@@ -121,7 +126,7 @@ public class AXSharpConfig : ICompilerOptions
         {
             AXSharpConfig.AxProjectFolder = directory;
         }
-
+        
         return AXSharpConfig;
     }
 

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
@@ -303,11 +303,11 @@ public class AXSharpProject : IAXSharpProject
                         "Target project is not a valid ITargetProject");
 
                 var project = new AXSharpProject(ax, BuilderTypes, targetProject.GetType(), dependnantCompilerOptions: this.CompilerOptions);
-
-            
+                
                 if (project.CompilerOptions.TargetPlatfromMoniker == null)
                 {
-                    throw new Exception("Target platform moniker must be set in the AXSharp.config.json file.");
+                    project.CompilerOptions.TargetPlatfromMoniker = "ax";
+                    Log.Logger.Warning("Target platform moniker should be set in the AXSharp.config.json file, passed as cli parameter. We deafault to 'ax'");
                 }
 
             project.Generate();

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
@@ -42,7 +42,7 @@ public class AXSharpProject : IAXSharpProject
     /// <param name="cliCompilerOptions">
     ///     Compiler options from CLI.
     /// </param>
-    public AXSharpProject(AxProject axProject, IEnumerable<Type> builderTypes, Type targetProjectType, ICompilerOptions? cliCompilerOptions = null)
+    public AXSharpProject(AxProject axProject, IEnumerable<Type> builderTypes, Type targetProjectType, ICompilerOptions? cliCompilerOptions = null, ICompilerOptions? dependnantCompilerOptions = null)
     {
         AxProject = axProject;
         CompilerOptions = AXSharpConfig.UpdateAndGetAXSharpConfig(axProject.ProjectFolder, cliCompilerOptions);
@@ -302,9 +302,15 @@ public class AXSharpProject : IAXSharpProject
                     throw new FailedToCreateTargetProjectException(
                         "Target project is not a valid ITargetProject");
 
-                var project = new AXSharpProject(ax, BuilderTypes, targetProject.GetType());
+                var project = new AXSharpProject(ax, BuilderTypes, targetProject.GetType(), dependnantCompilerOptions: this.CompilerOptions);
 
-                project.Generate();
+            
+                if (project.CompilerOptions.TargetPlatfromMoniker == null)
+                {
+                    throw new Exception("Target platform moniker must be set in the AXSharp.config.json file.");
+                }
+
+            project.Generate();
 
             if(!string.IsNullOrEmpty(ixProjectReference.AxProjectFolder))
                 compiled.Add(ixProjectReference.AxProjectFolder);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/Plain/IecToClrConverter.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/Plain/IecToClrConverter.cs
@@ -85,7 +85,7 @@ internal static class IecToClrConverter
     public static string CreateScalarInitializer(this IScalarTypeDeclaration scalar, string? targetPlatformMoniker)
     {
         if (targetPlatformMoniker == null)
-        {
+        {            
             throw new ArgumentNullException(nameof(targetPlatformMoniker), "Target platform moniker cannot be null.");
         }
 

--- a/src/AXSharp.compiler/src/ixc/Program.cs
+++ b/src/AXSharp.compiler/src/ixc/Program.cs
@@ -70,17 +70,17 @@ public static class Program
         }
     }
 
-    private static AXSharpProject GenerateIxProject(Options o)
-    {
-        var axProjectFolder = string.IsNullOrEmpty(o.AxSourceProjectFolder)
+    private static AXSharpProject GenerateIxProject(Options options)
+    {        
+        var axProjectFolder = string.IsNullOrEmpty(options.AxSourceProjectFolder)
             ? Environment.CurrentDirectory
-            : o.AxSourceProjectFolder;
+            : options.AxSourceProjectFolder;
 
         Environment.CurrentDirectory = GetFullPath(axProjectFolder);
 
         var ax = new AxProject(Environment.CurrentDirectory);
         var project = new AXSharpProject(ax, new[] { typeof(CsOnlinerSourceBuilder), typeof(CsPlainSourceBuilder) },
-            typeof(CsProject), o);
+            typeof(CsProject), options);
 
         var sw = new System.Diagnostics.Stopwatch();
         sw.Start();

--- a/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
+++ b/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
@@ -31,7 +31,7 @@
     },
     "axopen-traversal": {
       "commandName": "Project",
-      "workingDirectory": "C:\\W\\Develop\\gh\\inxton\\_axopen\\axopen\\src\\traversals\\apax\\"
+      "workingDirectory": "C:\\W\\Develop\\gh\\inxton\\ax\\axopen\\axopen\\src\\traversals\\apax\\"
     },
     "axopen-core": {
       "commandName": "Project",

--- a/src/AXSharp.compiler/tests/AXSharp.CompilerTests/CompilerTestOptions.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.CompilerTests/CompilerTestOptions.cs
@@ -1,0 +1,33 @@
+﻿// AXSharp.Compiler.CsTests
+// Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
+// Contributors: https://github.com/inxton/axsharp/graphs/contributors
+// See the LICENSE file in the repository root for more information.
+// https://github.com/inxton/axsharp/blob/dev/LICENSE
+// Third party licenses: https://github.com/inxton/axsharp/blob/master/notices.md
+
+using AXSharp.Compiler;
+
+namespace AXSharp.CompilerTests;
+
+
+public class CompilerTestOptions : ICompilerOptions
+{
+    private string _outputProject = null;
+    public string? OutputProjectFolder
+    {
+        get
+        {
+           return _outputProject;
+        }
+        set
+        {
+            _outputProject = value;
+        }
+    }
+    public string? ProjectFile { get => null; set { } }
+    public bool UseBase { get => false; set { } }
+    public bool NoDependencyUpdate { get => false; set { } }
+    public bool IgnoreS7Pragmas { get => false; set { } }
+    public bool SkipDependencyCompilation { get => false; set { } }
+    public string TargetPlatfromMoniker { get; set; } = "ax";
+}

--- a/src/AXSharp.compiler/tests/AXSharp.CompilerTests/IxProjectTests.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.CompilerTests/IxProjectTests.cs
@@ -22,6 +22,7 @@ using AX.ST.Semantic.Model;
 using AX.ST.Semantic.Pragmas;
 using AX.ST.Syntax.Tree;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using AXSharp.CompilerTests;
 
 namespace AXSharp.Compiler.Tests
 {
@@ -65,7 +66,7 @@ namespace AXSharp.Compiler.Tests
 
             var actual = new AXSharpProject(axproject,
                 new[] { builder },
-                target);
+                target, new CompilerTestOptions(), new CompilerTestOptions());
 
             actual.Generate();
 


### PR DESCRIPTION
This pull request includes several changes to the AXSharp compiler, focusing on adding support for dependent compiler options and improving project handling. The most important changes include updates to the `AXSharpConfig` and `AXSharpProject` classes, as well as adjustments to test files to accommodate the new functionality.

### Updates to AXSharpConfig and AXSharpProject:

* [`src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpConfig.cs`](diffhunk://#diff-795c0893271ff4a469d4d5fdbdb5f53d0c0f79a2d5b563f36cef02fdcfefa96eL84-R84): Added a new parameter `dependnantCompilerOptions` to the `UpdateAndGetAXSharpConfig` method to support dependent compiler options.
* [`src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpConfig.cs`](diffhunk://#diff-795c0893271ff4a469d4d5fdbdb5f53d0c0f79a2d5b563f36cef02fdcfefa96eR102-R106): Updated the method to apply `TargetPlatfromMoniker` from `dependnantCompilerOptions` if provided.
* [`src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs`](diffhunk://#diff-01fd5fc7cedda55d6f79d9a2b1d1d29174e633badec0a70e4be9934a52a141e4L45-R45): Added a new parameter `dependnantCompilerOptions` to the `AXSharpProject` constructor to support dependent compiler options.
* [`src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs`](diffhunk://#diff-01fd5fc7cedda55d6f79d9a2b1d1d29174e633badec0a70e4be9934a52a141e4L305-R311): Modified `CompileProjectReferences` to pass `dependnantCompilerOptions` and set a default `TargetPlatfromMoniker` if not specified.

### Adjustments to test files:

* [`src/AXSharp.compiler/tests/AXSharp.CompilerTests/CompilerTestOptions.cs`](diffhunk://#diff-fa2d9da1cc7e3e40b54827c0ee58d6df665a496bc36be231b174c23843764bd3R1-R33): Added a new class `CompilerTestOptions` implementing `ICompilerOptions` for testing purposes.
* [`src/AXSharp.compiler/tests/AXSharp.CompilerTests/IxProjectTests.cs`](diffhunk://#diff-6e597a815211a32a725427f718606c88b004f669bec8c1d9d970f0b271057376L68-R69): Updated test case `should_generate_output_of_ix_project` to use the new `CompilerTestOptions` class.

closes #370