### PR TITLE
Fixes an issue with interpratation of Date type when reading from the…

### DIFF
--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs
@@ -101,8 +101,8 @@ public class WebApiDate : OnlinerDate, IWebApiPrimitive
         switch (_webApiConnector.TargetPlatform)
         {
             case eTargetProjectPlatform.TIAPORTAL:
-                int val = ((int)value) - 1;
-                return DateOnly.FromDayNumber(val).AddYears(1989);
+                //int val = ((int)value) - 1;
+                return ((int)value).GetDateOnly();//DateOnly.FromDayNumber((int)value).AddYears(1989);
 
             case eTargetProjectPlatform.SIMATICAX:
                 var valAx = value / 100;

--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs
@@ -57,6 +57,17 @@ public static class WebApiConnectorExtensions
         { Parameters = new object[] { ipAddress, userName, password, customServerCertHandler, ignoreSslErrors, platform, dbName } };
     }
 
+    public static DateOnly GetDateOnly(this int value)
+    {
+        // 1 tick = 100 ns
+        // Use DateTimeKind.Utc for correct interpretation
+        var dateTime = new DateTime(1990, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                           .AddDays(value);
+
+        // Return the date portion in UTC
+        return DateOnly.FromDateTime(dateTime.ToUniversalTime());
+    }
+
     public static DateOnly GetDateOnly(this long value)
     {
         // 1 tick = 100 ns


### PR DESCRIPTION
This pull request includes changes to the `AXSharp.Connector.S71500.WebAPI` project to improve date handling and simplify the code. The most important changes include modifying the `GetFromBinary` method and adding a new `GetDateOnly` extension method for `int` values.

Improvements to date handling:

* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/BuiltInWrappers/WebApiDate.cs`](diffhunk://#diff-23455ce2ea78aaeba5ba88bfb15881ea5e8e5072dfc4d379006944f5262ec998L104-R105): Modified the `GetFromBinary` method to use the new `GetDateOnly` extension method for `int` values, simplifying the date conversion logic.

Codebase simplification:

* [`src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnectorExtensions.cs`](diffhunk://#diff-65e3da4d8fc57ca29a968f2f7b2ae35ff5c4123bf213055cd4443b7f7eed7d49R60-R70): Added a new `GetDateOnly` extension method for `int` values to handle date conversion, ensuring consistency and reducing code duplication.

Closes #369 