### PR TITLE
Refactor simplify polling on generated componenents

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,6 +32,7 @@ jobs:
       run: dotnet build cake/Build.csproj
                        
     - name: "Run cake script"
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'false' }}
       env:
           GH_TOKEN : ${{ secrets.GH_TOKEN }}
       run: dotnet run --project cake/Build.csproj --do-test --do-pack --test-level 2 --framework net9.0
@@ -47,4 +48,4 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
         GH_USER: ${{ secrets.GH_USER }}
-      run: dotnet run --project cake/Build.csproj --do-publish-only --do-publish --do-publish-release --framework net9.0
+      run: dotnet run --project cake/Build.csproj --do-test --do-pack --test-level 2 --do-publish-only --do-publish --do-publish-release --framework net9.0

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,3 @@
 # run build
 dotnet run --project cake/Build.csproj --framework net9.0 -- $args
-exit $LASTEXITCODE;vm43001Jetpow3r
+exit $LASTEXITCODE;

--- a/cake/BuildParameters.cs
+++ b/cake/BuildParameters.cs
@@ -33,7 +33,4 @@ public class BuildParameters
 
     [Option('r', "do-publish-release", Required = false, Default = false, HelpText = "Publishes release on GH")]
     public bool DoPublishRelease { get; set; }
-
-    [Option('o', "do-publish-only", Required = false, Default = false, HelpText = "Perfoms only publishing tasks from previously created artefacts.")]
-    public bool DoPublishOnly { get; set; }
 }

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -65,12 +65,6 @@ public sealed class CleanUpTask : FrostingTask<BuildContext>
 {    
     public override void Run(BuildContext context)
     {
-        if(context.BuildParameters.DoPublishOnly)
-        {
-            context.Log.Warning($"Skipping. Preforming publish only");
-            return;
-        }
-
         context.DotNetClean(Path.Combine(context.ScrDir, "AXSharp.sln"), new DotNetCleanSettings() { Verbosity = context.BuildParameters.Verbosity });
         context.CleaUpAllBinsAndObjs();
         context.CleanDirectory(context.Artifacts);
@@ -84,12 +78,6 @@ public sealed class ProvisionTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-        if (context.BuildParameters.DoPublishOnly)
-        {
-            context.Log.Warning($"Skipping. Preforming publish only");
-            return;
-        }
-
         context.DotNetBuildSettings.MSBuildSettings.Properties.Add("NoWarn", new List<string>() 
             { "1234;2345;8602;10012;8618;0162;8605;1416;3270;1504;8600;8618;" +
                 "CS0618;CS1591;BL0007;BL0005;CA1416;CA2200;CS0105;CS0108;CS0109;CS0162;CS0168;CS0169;CS219;CS0414;CS0436;CS0472;CS0618;CS1591;CS1998;CS8604;" +
@@ -132,13 +120,6 @@ public sealed class BuildTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-
-        if (context.BuildParameters.DoPublishOnly)
-        {
-            context.Log.Warning($"Skipping. Preforming publish only");
-            return;
-        }
-
         context.DotNetBuild(Path.Combine(context.ScrDir, "AXSharp.compiler\\src\\ixc\\AXSharp.ixc.csproj"), context.DotNetBuildSettings);
 
         var axprojects = new List<string>()
@@ -173,12 +154,6 @@ public sealed class TestsTask : FrostingTask<BuildContext>
     // Tasks can be asynchronous
     public override void Run(BuildContext context)
     {
-        if (context.BuildParameters.DoPublishOnly)
-        {
-            context.Log.Warning($"Skipping. Preforming publish only");
-            return;
-        }
-
         if (!context.BuildParameters.DoTest)
         {
             context.Log.Warning($"Skipping tests");
@@ -241,12 +216,6 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
 {
     public override void Run(BuildContext context)
     {
-        if (context.BuildParameters.DoPublishOnly)
-        {
-            context.Log.Warning($"Skipping. Preforming publish only");
-            return;
-        }
-
         if (!context.BuildParameters.DoPack)
         {
             context.Log.Warning($"Skipping packaging.");

--- a/cake/Properties/launchSettings.json
+++ b/cake/Properties/launchSettings.json
@@ -4,10 +4,13 @@
       "commandName": "WSL2",
       "distributionName": ""
     },
+    "build": {
+      "commandName": "Project"            
+    },
     "PublishOnly": {
       "commandName": "Project",
       "commandLineArgs": "--do-publish-only --do-publish --do-publish-release",
       "workingDirectory": "C:\\W\\Develop\\gh\\inxton\\ax\\axsharp\\cake"
-    }
+    }    
   }
 }

--- a/docfx/articles/blazor/LIBRARIES.md
+++ b/docfx/articles/blazor/LIBRARIES.md
@@ -181,34 +181,33 @@ Note: viewmodel properties and variables can be accessed with inherited `ViewMod
 
 ## Optimizing PLC Data Polling
 
-The `RenderableComponentBase` class contains an overridable method, `AddToPolling`, which is primarily tasked with adding elements to the polling queue. However, given the automatic subscription of all inner elements within a given object to the polling queue by default, it becomes imperative to manage this operation more precisely, especially when dealing with large objects.
+The `RenderableComponentBase` class contains an overridable method, `ConfigurePolling`, which is tasked with adding elements to the polling queue and **must be overridden** in derived components. By default, no polling is activated; it must be explicitly stated which primitives or twin objects should be added to the polling queue.
 
 Overriding this method in derived classes allows for the customization of how many and which elements are added to the polling queue. This capability is crucial for controlling resources and optimizing performance by preventing the automatic addition of potentially large numbers of elements to the polling queue.
+
+Whenever the `RenderableComponent` is disposed, the polling for that component is automatically released in the `Dispose` method.
+
+>[!IMPORTANT]
+>Whenever the `OnInitialized`, `OnInitializedAsync`, or `Dispose` methods are overridden, it is imperative that `base` is called to ensure the proper sequence of polling management.
+
 
 Here is an example where the overridden method ensures that no elements are added to the polling queue:
 
 ```C#
-public override void AddToPolling(ITwinElement element, int pollingInterval = 250)
+public override void ConfigurePolling()
 {
     // Overriding with an empty method ensures no elements are added to the polling queue.
 }
 ```
 
-Contrastingly, in the following example, the overridden method only subscribes first-level primitive elements for polling, thus creating a more resource-efficient application:
-
 ```C#
-public override void AddToPolling(ITwinElement element, int pollingInterval = 250)
+public override void ConfigurePolling()
 {
-    var sequencer = (AxoSequencer)element;
-    var firstLevelPrimitives = sequencer.GetValueTags().ToList();
-
-    firstLevelPrimitives.ForEach(p =>
-    {
-        p.StartPolling(pollingInterval, this);
-        PolledElements.Add(p);
-    });
+    this.StartPolling(this.Component.Counter, 1500);
+    this.StartPolling(this.Component.Counter2, 250);
 }
 ```
+
 This strategy allows for a more efficient use of resources by reducing the load of polled elements on the system.
 
 For more details about polling [General Polling](../connectors/README.md#polling).

--- a/docfx/articles/connectors/README.md
+++ b/docfx/articles/connectors/README.md
@@ -21,13 +21,17 @@ Each elementary/primitive/base type is represented by twin wrapper objects that 
 **Cyclic access** allows for fast, low-performance cost, two-way access to the PLC variables. Cyclic values are read and written in an optimized periodic loop. The controller twin object contains the entire PLC program, it does not discriminate between the variables and objects that are used by the consumer and those that are not. However, the Cyclic values are accessed via the communication interface only when:
 
 - Twin connector is set to `Auto` subscription, which will set the variable into a cyclic read queue when `Cyclic` property is accessed in the consumer program.
-- Twin connector is set to `Polling` subscription, and reading is activated by `StartPolling`.
+- Twin connector is set to `Polling` subscription, and reading is activated by `StartPolling`. Polling can be stopped by calling the `StopPolling` method.
+
+The polling mechanism keeps track of polling subscribers or holders and will only release the polling when the last subscriber calls the `StopPolling` method. It is good practice to call `StopPolling` when the holder/subscriber object is disposed.
+
+
+> **WARNING** 
+> Cyclic access may result in degraded performance when the cyclic loop contains too many cyclically accessed primitive twins. Consider using `polling` instead of `automatic` subscription to balance the communication load.
 
 
 Primitive Twins implement notification change when the cyclic property changes [INotifyPropertyChanged](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifypropertychanged?view=net-7.0). This feature is particularly useful for visualization scenarios in presentation frameworks that support data binding with change notification (WPF, Blazor, WinForm).
 
-> **WARNING** 
-> Cyclic access may result in degraded performance when the cyclic loop contains too many cyclically accessed primitive twins. Consider using `polling` instead of `automatic` subscription to balance the communication load.
 
 ~~~ C#
     // Cyclic Read

--- a/docfx/articles/connectors/WebAPI.md
+++ b/docfx/articles/connectors/WebAPI.md
@@ -49,7 +49,7 @@ Entry.Plc.Connector.SetLoggerConfiguration(new LoggerConfiguration()
 
 ## Performance
 
-Communication via WebAPI has inherent performance constraints based on the target system, request frequency, and payload size. The S71500.WebAPI connector tackles the 64kB limit for single requests by fragmenting them into manageable chunks. However, there is a restriction on the number of requests that can be sent to the controller simultaneously. The maximum threshold is four simultaneous requests, though this can be reduced. Any requests exceeding this limit will be queued and processed after a specified waiting period. 
+Communication via WebAPI has inherent performance constraints based on the target system, request frequency, and payload size. The S71500.WebAPI connector tackles the 128kB limit for single requests by fragmenting them into manageable chunks. However, there is a restriction on the number of requests that can be sent to the controller simultaneously. The maximum threshold is four simultaneous requests, though this can be reduced. Any requests exceeding this limit will be queued and processed after a specified waiting period. 
 
 > [!NOTE]
 > It's worth noting that the controller might be communicating with other devices like HMI or OPC-UA, further intensifying the overall communication load.

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/AXSharp.Presentation.Blazor.Controls.csproj
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/AXSharp.Presentation.Blazor.Controls.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	    <Folder Include="RenderableContentControl\" />
 	    <Folder Include="wwwroot\js\" />
   </ItemGroup>
 

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableComplexComponentBase.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableComplexComponentBase.cs
@@ -19,7 +19,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
     /// <summary>
     ///  Base class for complex components with only code-behind.
     /// </summary>
-    public class RenderableComplexComponentBase<T> : RenderableComponentBase, IRenderableComplexComponentBase where T : ITwinElement
+    public abstract class RenderableComplexComponentBase<T> : RenderableComponentBase, IRenderableComplexComponentBase where T : ITwinElement
     {
         private T _component;
 

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableComponentBase.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableComponentBase.cs
@@ -91,9 +91,8 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// <summary>
         ///  Method, which updates are primitive values of ITwinObject instance
         /// <param name="element">ITwinObject instance.</param>
-        /// <param name="pollingInterval">Polling interval</param>
         /// </summary>
-        private void UpdateValuesOnChange(ITwinObject element,int pollingInterval = 250)
+        private void UpdateValuesOnChange(ITwinObject element)
         {
             if (element != null)
             {
@@ -108,9 +107,8 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// <summary>
         ///  Method, which updates primitive value.
         /// <param name="tag">IValueTag instance.</param>
-        /// <param name="pollingInterval">Polling interval</param>
         /// </summary>
-        private void UpdateValuesOnChange(OnlinerBase tag, int pollingInterval = 250)
+        private void UpdateValuesOnChange(OnlinerBase tag)
         {
             tag.PropertyChanged += new PropertyChangedEventHandler(HandlePropertyChanged);
         }
@@ -118,17 +116,16 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// <summary>
         ///  Method, which updates are primitive values of ITwinObject instance
         /// <param name="element">ITwinElement instance.</param>
-        /// <param name="pollingInterval">Polling interval</param>
         /// </summary>
-        private void UpdateValuesOnChange(ITwinElement element, int pollingInterval = 250)
+        private void UpdateValuesOnChange(ITwinElement element)
         {
             switch (element)
             {
                 case ITwinObject o:
-                    UpdateValuesOnChange(o, pollingInterval);
+                    UpdateValuesOnChange(o);
                     break;
                 case OnlinerBase b:
-                    UpdateValuesOnChange(b, pollingInterval);
+                    UpdateValuesOnChange(b);
                     break;
             }
         }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableComponentBase.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableComponentBase.cs
@@ -23,7 +23,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
     /// <summary>
     ///  Base class which implements methods to update UI when PLC values are changed.
     /// </summary>
-    public partial class RenderableComponentBase : ComponentBase, IRenderableComponent, IDisposable
+    public abstract class RenderableComponentBase : ComponentBase, IRenderableComponent, IDisposable
     {
         /// <summary>
         /// Gets or sets the RenderableContentControl that encapsulates this component.
@@ -38,7 +38,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// </summary>
         public virtual void Dispose()
         {
-            RemovePolledElements();
+            StopPolling();
         }
 
         /// <summary>
@@ -51,21 +51,34 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// <summary>
         /// Adds <see cref="element"/> to the polling queue.
         /// >[!IMPORTANT] This method should be overriden in the derived class to limit the number of elements to be polled for large objects.
-        /// > All inner primitive types of the element will be added to the polling queue by default. When creating override remember to add the polled element to
-        /// > the <see cref="PolledElements"/> set that is needed for removal of the element from the polling queue once the component is disposed.
+        /// > None of inner primitive types of the element will be added to the polling queue by default.
+        /// > When creating override remember to add the polled element to the <see cref="PolledElements"/>
+        /// > set that is needed for removal of the element from the polling queue once the component is disposed.
         /// </summary>
-        /// <param name="element">Element to be added to the polling queue.</param>
-        /// <param name="pollingInterval">Sets polling interval for the element.</param>
-        public virtual void AddToPolling(ITwinElement element, int pollingInterval = 250) 
+        /// <example>
+        /// <code>
+        ///     /// This will add all primitives from the component object to polling.
+        ///     this.StartPolling(this.Component, pollingInterval);
+        /// </code>
+        /// </example>
+        public abstract void ConfigurePolling(); 
+        
+        /// <summary>
+        /// Starts polling the element.
+        /// </summary>
+        /// <param name="element">Element to be polled.</param>
+        /// <param name="pollingInterval">Polling interval</param>
+        public void StartPolling(ITwinElement element, int pollingInterval = 250)
         {
             element.StartPolling(pollingInterval, this);
+            this.UpdateValuesOnChange(element);
             PolledElements.Add(element);
         }
 
         /// <summary>
         /// Removes elements added for polling from this component.
         /// </summary>
-        public void RemovePolledElements()
+        public void StopPolling()
         {
             PolledElements.ToList().ForEach(p =>
             {
@@ -80,7 +93,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// <param name="element">ITwinObject instance.</param>
         /// <param name="pollingInterval">Polling interval</param>
         /// </summary>
-        private void UpdateValuesOnChange(ITwinObject element, int pollingInterval = 250)
+        private void UpdateValuesOnChange(ITwinObject element,int pollingInterval = 250)
         {
             if (element != null)
             {
@@ -107,10 +120,8 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         /// <param name="element">ITwinElement instance.</param>
         /// <param name="pollingInterval">Polling interval</param>
         /// </summary>
-        public void UpdateValuesOnChange(ITwinElement element, int pollingInterval = 250)
+        private void UpdateValuesOnChange(ITwinElement element, int pollingInterval = 250)
         {
-            AddToPolling(element, pollingInterval);
-
             switch (element)
             {
                 case ITwinObject o:
@@ -157,6 +168,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
             tag.PropertyChanged += new PropertyChangedEventHandler(HandlePropertyChangedOnOutFocus);
         }
 
+   
         protected void HandlePropertyChanged(object sender, PropertyChangedEventArgs a)
         {
             if (ShouldBeUpdated(sender as ITwinElement))
@@ -165,11 +177,17 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
             }
         }
 
+        /// <summary>
+        /// Method, which updates shadow primitive
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="a"></param>
         protected void HandleShadowPropertyChanged(object sender, ValueChangedEventArgs a)
         {
             InvokeAsync(StateHasChanged);
         }
 
+        
         protected virtual bool ShouldBeUpdated(ITwinElement element)
         {
             if (element == null)
@@ -202,7 +220,13 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
                     InvokeAsync(StateHasChanged);
                 }
             }
-                
+        }
+
+
+        protected override Task OnInitializedAsync()
+        {
+            ConfigurePolling();
+            return base.OnInitializedAsync();
         }
     }
 }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableContentControl.razor.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableContentControl.razor.cs
@@ -150,16 +150,11 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
         private Type _groupContainer { get; set; }
         public Type MainLayoutType { get; set; }
 
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-
-                
-        }
-
         /// <summary>
         /// Forces re-rendering of this rcc.
-        /// [!IMPORTANT] Forced re-rendering may impact client-side performance. The method is automatically called when <see cref="Presentation"/> or <see cref="Context"/> property change.
+        /// [!IMPORTANT]
+        /// > Forced re-rendering may impact client-side performance.
+        /// > The method is automatically called when <see cref="Presentation"/> or <see cref="Context"/> property change.
         /// </summary>
         public void ForceRender()
         {
@@ -282,6 +277,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
             __builder.AddAttribute(2, "Onliner", twinPrimitive);
             __builder.AddAttribute(3, "IsReadOnly", HasReadAccess(twinPrimitive));
             __builder.AddAttribute(1, "RccContainer", this);
+            __builder.AddAttribute(4, "PollingInterval", this.PollingInterval);
             __builder.CloseComponent();
         };
 

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableContentControl.razor.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableContentControl.razor.cs
@@ -187,26 +187,7 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
 
         private bool _pollingStarted = false;
 
-        private void SubscribeForPolling(IRenderableComponent component, ITwinElement element)
-        {
-            var presentation = this.Presentation;
-            if (presentation != null && presentation.StartsWith("Shadow")) return;
-            if (component == null) return;
-            if(PolledComponents.Contains(component)) return;
-            PolledComponents?.Add(component);
-            component?.AddToPolling(element, this.PollingInterval);
-            _pollingStarted = true;
-        }
-
-        private void UnSubscribeFromPolling()
-        {
-            foreach (var renderableComponent in PolledComponents)
-            {
-                renderableComponent?.RemovePolledElements();
-            }
-
-            _pollingStarted = false;
-        }
+        
 
         /// <summary>
         /// Method to build component name from passed parameters, which instance will be found in assembly.
@@ -245,7 +226,6 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
                     // try to find override template component view
                     var buildedComponentName = $"{overrideAttribute.TemplateOverrideName}{presentationName}View";
                     component = ComponentService.GetComponent(buildedComponentName);
-                    SubscribeForPolling(component, twin);
                 }
                 if(component == null) // if not set and foun override template
                 {
@@ -469,7 +449,6 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
                         var onlinerName = $"{namespc}.{baseName}";
                         var onlinerBuildedComponentName = $"{onlinerName}{presentationName}View`1";
                         var genericComponent = ComponentService.GetGenericComponent(onlinerBuildedComponentName, genericTypeArg);
-                        SubscribeForPolling(genericComponent, twin);
                         return genericComponent;
                     }
                     else
@@ -477,14 +456,12 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
                         var onlinerName = $"{namespc}.{twinType.Name}";
                         var onlinerBuildedComponentName = $"{onlinerName}{presentationName}View";
                         var primitiveComponent = ComponentService.GetComponent(onlinerBuildedComponentName);
-                        SubscribeForPolling(primitiveComponent, twin);
                         return primitiveComponent;
                     }
                 default:
                     var name = $"{namespc}.{FilterOutGeneric(twinType.Name)}";
                     var buildedComponentName = $"{name}{presentationName}View";
                     var defaultComponent = ComponentService.GetComponent(buildedComponentName);
-                    SubscribeForPolling(defaultComponent, twin);
                     return defaultComponent;
             }
         }
@@ -539,7 +516,6 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
 
         public virtual void Dispose()
         {
-            UnSubscribeFromPolling();
             _viewModelCache.ResetCounter();
         }
     }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableViewModelComponentBase.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/RenderableContent/RenderableViewModelComponentBase.cs
@@ -23,14 +23,12 @@ namespace AXSharp.Presentation.Blazor.Controls.RenderableContent
     /// <summary>
     ///  Base class for complex components with viewmodel support.
     /// </summary>
-    public class RenderableViewModelComponentBase<T> : RenderableComponentBase, IRenderableViewModelBase where T : RenderableViewModelBase, new()
+    public abstract class RenderableViewModelComponentBase<T> : RenderableComponentBase, IRenderableViewModelBase where T : RenderableViewModelBase, new()
     {
         [Inject]
         private ViewModelCacheService _viewModelCache { get; set; }
 
         private TwinContainerObject _twinContainer;
-
-       
 
         [Parameter]
         public TwinContainerObject TwinContainer

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Base/Online/TemplateBaseOnline.razor.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Base/Online/TemplateBaseOnline.razor.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using AXSharp.Connector;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 
 
@@ -17,10 +18,6 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace AXSharp.Presentation.Blazor.Controls.Templates
 {
-    
-
-
-
     public partial class TemplateBaseOnline<T> : TemplateBase<T>
     {
         protected string ToolTipText => string.IsNullOrEmpty(Onliner.AttributeToolTip)
@@ -29,9 +26,15 @@ namespace AXSharp.Presentation.Blazor.Controls.Templates
 
         protected override Task OnInitializedAsync()
         {
-            AddToPolling(this.Onliner, this.PollingInterval);
             UpdateValuesOnChangeOutFocus(Onliner);
+            ConfigurePolling();
             return base.OnInitializedAsync();
+        }
+
+
+        public override void ConfigurePolling()
+        {
+            StartPolling(this.Onliner, this.PollingInterval);
         }
     }
 }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Base/Shadow/TemplateBaseShadow.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Base/Shadow/TemplateBaseShadow.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AXSharp.Connector;
 
 namespace AXSharp.Presentation.Blazor.Controls.Templates
 {
@@ -30,6 +31,11 @@ namespace AXSharp.Presentation.Blazor.Controls.Templates
         {
            // UpdateShadowValuesOnChange(Onliner);
             return base.OnInitializedAsync();
+        }
+
+        public override void ConfigurePolling()
+        {
+            // No polling for shadow values
         }
     }
 }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Enumerators/Online/EnumeratorsBaseOnline.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Enumerators/Online/EnumeratorsBaseOnline.cs
@@ -21,9 +21,12 @@ namespace AXSharp.Presentation.Blazor.Controls.Templates
         {
             EnumToIntConverter = new EnumToIntConverter(EnumDiscriminatorAttribute);
             Names = Enum.GetNames(EnumDiscriminatorAttribute.EnumeratorType);
-            UpdateValuesOnChange(Onliner);
             return base.OnInitializedAsync();
         }
 
+        public override void ConfigurePolling()
+        {
+            this.StartPolling(Onliner);
+        }
     }
 }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Enumerators/Shadow/EnumeratorsBaseShadow.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/Enumerators/Shadow/EnumeratorsBaseShadow.cs
@@ -23,5 +23,10 @@ namespace AXSharp.Presentation.Blazor.Controls.Templates
             UpdateShadowValuesOnChange(Onliner);
             return base.OnInitializedAsync();
         }
+
+        public override void ConfigurePolling()
+        {
+            // No polling for shadow values.
+        }
     }
 }

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/TemplateBase.razor.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/Templates/TemplateBase.razor.cs
@@ -7,11 +7,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AXSharp.Connector;
 
 
 namespace AXSharp.Presentation.Blazor.Controls.Templates
 {
-    public partial class TemplateBase<T> : RenderableComponentBase
+    public abstract class TemplateBase<T> : RenderableComponentBase
     {
         private IJSObjectReference? module;
 

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor/Interfaces/IRenderableComponent.cs
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor/Interfaces/IRenderableComponent.cs
@@ -11,17 +11,11 @@ namespace AXSharp.Presentation.Blazor.Interfaces
 {
     public interface IRenderableComponent
     {
-        /// <summary>
-        /// Adds <see cref="element"/> to the polling queue.
-        /// <param name="element">Element to be added to the polling queue.</param>
-        /// <param name="pollingInterval">Sets polling interval for the element.</param>
-        void AddToPolling(ITwinElement element, int pollingInterval = 250);
 
+        void ConfigurePolling();
         /// <summary>
         /// Removes elements added for polling from this component.
         /// </summary>
-        void RemovePolledElements();
-
-        
+        void StopPolling();
     }
 }

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentBaseView/IxComponentView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentBaseView/IxComponentView.razor
@@ -11,8 +11,8 @@
 <input type="text" @bind="ViewModel.DummyText"/>
 @code
 {
-    protected override void OnInitialized()
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(ViewModel.Component);
+        StartPolling(ViewModel.Component);
     }
 }

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentManualView/IxComponentManualView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentManualView/IxComponentManualView.razor
@@ -10,12 +10,8 @@
 <input type="text" @bind="ViewModel.ViewModelProperty" />
 @code
 {
-  
-
-    
-
-    protected override void OnInitialized()
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(ViewModel.Component);
+        StartPolling(this.ViewModel.Component);
     }
 }

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentServiceView/IxComponentServiceView.cs
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentServiceView/IxComponentServiceView.cs
@@ -18,7 +18,13 @@ namespace ax_blazor_example
     {
         protected override void OnInitialized()
         {
-            UpdateValuesOnChange(Component);
+            StartPolling(Component);
+        }
+
+
+        public override void Dispose()
+        {
+            this.StopPolling();
         }
     }
 }

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentServiceView/IxComponentServiceView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/IxComponentServiceView/IxComponentServiceView.razor
@@ -7,3 +7,12 @@
 <p>IxBool service value: @Component.ix_bool.Cyclic</p>
 <p>IxInt service value: @Component.ix_int.Cyclic</p>
 <p>IxString service value: @Component.ix_string.Cyclic</p>
+
+
+@code
+{
+    public override void ConfigurePolling()
+    {
+        StartPolling(this.Component);
+    }
+}

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/StTest3ManualView/StTest3ManualView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/StTest3ManualView/StTest3ManualView.razor
@@ -4,6 +4,11 @@
 
 
 <input type="text" @bind="ViewModel.DummyText" />
+
 @code {
 
+    public override void ConfigurePolling()
+    {
+        StartPolling(this.ViewModel.Component);
+    }
 }

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/TcoIxObjectBaseView/TcoIxObjectView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/TcoIxObjectBaseView/TcoIxObjectView.razor
@@ -4,4 +4,8 @@
 
 @code {
 
+    public override void ConfigurePolling()
+    {
+        StartPolling(this.Component);
+    }
 }

--- a/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/TcoIxObjectDiagnoticsView/TcoIxObjectDiagnosticsView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/ComponentsExamples/TcoIxObjectDiagnoticsView/TcoIxObjectDiagnosticsView.razor
@@ -9,4 +9,9 @@
 
 @code {
 
+    public override void ConfigurePolling()
+    {
+        StartPolling(this.Component);
+    }
+
 }

--- a/src/AXSharp.blazor/tests/sandbox/IxBlazor.App/Custom/MySimplePrimitiveStructDisplayView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/IxBlazor.App/Custom/MySimplePrimitiveStructDisplayView.razor
@@ -6,3 +6,10 @@
     <h1>Overrided My Simple Primitive Struct Display View</h1>
 </div>
 
+@code
+{
+    public override void ConfigurePolling()
+    {
+        StartPolling(this.Component);
+    }
+}

--- a/src/AXSharp.blazor/tests/sandbox/IxBlazor.App/Custom/MySimplePrimitiveTagDisplayView.razor
+++ b/src/AXSharp.blazor/tests/sandbox/IxBlazor.App/Custom/MySimplePrimitiveTagDisplayView.razor
@@ -13,8 +13,8 @@
     [Parameter]
     public bool IsReadOnly { get; set; }
 
-    protected override void OnInitialized()
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Onliner);
+        StartPolling(Onliner);
     }
 }

--- a/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/Connector/Connector.cs
@@ -391,7 +391,20 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
         desiredCulture = culture;
     }
 
-   
+    /// <summary>
+    /// Start polling queue of subscribed items.
+    /// </summary>
+    public void StartSubscriptionPolling(int pollingInterval = 100)
+    {
+        Task.Run(async () =>
+        {
+            while (true)
+            {
+                await Task.Delay(pollingInterval);
+                await ReadBatchAsync(this.Subscribed.Values);
+            }
+        });
+    }
 
     /// <summary>
     ///     Starts cyclical read write operation on this connector.
@@ -401,7 +414,7 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
         var sw = new Stopwatch();
         long cycleCount = 0;
         var startTimeStamp = DateTime.Now;
-        
+
         await Task.Run(async () =>
         {
             while (true)
@@ -440,6 +453,8 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
     }
 
     
+
+
     /// <summary>
     ///     Reads online variables required to be read.
     /// </summary>
@@ -448,7 +463,7 @@ public abstract class Connector : RootTwinObject, INotifyPropertyChanged
        
         var primitivesToRead = new List<ITwinPrimitive>();
         primitivesToRead.AddRange(NextPeriodicReadSet.Values);
-        primitivesToRead.AddRange(Subscribed.Values);
+        //primitivesToRead.AddRange(Subscribed.Values);
         var distinctPrimitivesToRead = primitivesToRead.Distinct().ToList();
 
         if (distinctPrimitivesToRead.Any())

--- a/src/sanbox/integration/ix-integration-blazor/Components/IxComponentView.razor
+++ b/src/sanbox/integration/ix-integration-blazor/Components/IxComponentView.razor
@@ -11,9 +11,10 @@
 
 
 <RenderableContentControl Context="Component.my_int" Presentation="Control"></RenderableContentControl>
-@code {
-    protected override void OnInitialized()
+@code 
+{
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Component);
+        StartPolling(Component);
     }
 }

--- a/src/sanbox/integration/ix-integration-blazor/Components/MeasurementServiceView.razor
+++ b/src/sanbox/integration/ix-integration-blazor/Components/MeasurementServiceView.razor
@@ -9,8 +9,8 @@
 
 @code
 {
-    protected override void OnInitialized()
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Component);
+        StartPolling(Component);
     }
 }

--- a/src/sanbox/integration/ix-integration-library/IxComponentServiceViewModel/IxComponentServiceView.razor
+++ b/src/sanbox/integration/ix-integration-library/IxComponentServiceViewModel/IxComponentServiceView.razor
@@ -1,4 +1,5 @@
 ﻿@namespace AXSharp.Presentation.Blazor.Controls.Templates
+@using AXSharp.Connector
 @using ix_integration_library.IxComponentServiceViewModel
 @inherits RenderableViewModelComponentBase<IxComponentViewModel>
 
@@ -12,8 +13,8 @@
 
 
 @code {
-    protected override void OnInitialized()
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(ViewModel.Component);
+        StartPolling(ViewModel.Component);
     }
 }

--- a/src/sanbox/integration/ix-integration-library/IxComponentView/IxComponentView.razor
+++ b/src/sanbox/integration/ix-integration-library/IxComponentView/IxComponentView.razor
@@ -1,4 +1,5 @@
 ﻿@namespace AXSharp.Presentation.Blazor.Controls.Templates
+@using AXSharp.Connector
 @inherits RenderableComplexComponentBase<ixcomponent>
 
 <h3>Global namespace</h3>
@@ -11,8 +12,9 @@
 
 
 @code{
-    protected override void OnInitialized()
+
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Component);
+        StartPolling(Component);
     }
 }

--- a/src/sanbox/integration/ix-integration-library/IxComponentViewSecond/IxComponentView.razor
+++ b/src/sanbox/integration/ix-integration-library/IxComponentViewSecond/IxComponentView.razor
@@ -1,4 +1,5 @@
 ﻿@namespace MySecondNamespace
+@using AXSharp.Connector
 @inherits RenderableComplexComponentBase<ixcomponent>
 
 <h3>Second namespace</h3>
@@ -11,8 +12,9 @@
 
 
 @code{
-    protected override void OnInitialized()
+
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Component);
+        StartPolling(Component);
     }
 }

--- a/src/sanbox/integration/ix-integration-library/IxComponentViewThird/IxComponentView.razor
+++ b/src/sanbox/integration/ix-integration-library/IxComponentViewThird/IxComponentView.razor
@@ -1,4 +1,5 @@
 ﻿@namespace ThirdNamespace
+@using AXSharp.Connector
 @inherits RenderableComplexComponentBase<ixcomponent>
 
 <h3>Third Namespace</h3>
@@ -11,8 +12,9 @@
 
 
 @code{
-    protected override void OnInitialized()
+
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Component);
+        StartPolling(Component);
     }
 }

--- a/src/sanbox/integration/ix-integration-library/taskExample/TaskExampleView.razor
+++ b/src/sanbox/integration/ix-integration-library/taskExample/TaskExampleView.razor
@@ -1,4 +1,5 @@
 ﻿@namespace AXSharp.Presentation.Blazor.Controls.Templates
+@using AXSharp.Connector
 @inherits RenderableComplexComponentBase<TaskExample>
 
     <div class="btn-group form-group mb-2">
@@ -57,12 +58,11 @@
 
     public string ButtonClass = "btn-primary";
 
-   public bool IsTaskRunning => false;
+    public bool IsTaskRunning => false;
     public bool IsTaskAborted => false;
 
-    protected override void OnInitialized()
+    public override void ConfigurePolling()
     {
-        UpdateValuesOnChange(Component);
-        
+        StartPolling(Component);
     }
 }

--- a/src/tests.integrations/integrated/src/integrated.app/Pages/UI/ManualUI.razor
+++ b/src/tests.integrations/integrated/src/integrated.app/Pages/UI/ManualUI.razor
@@ -6,3 +6,11 @@
 <div class="container">
     <RenderableContentControl Context="@Entry.Plc.Pokus" Presentation="Control" />
 </div>
+
+@code
+{
+    public override void ConfigurePolling()
+    {
+        
+    }
+}


### PR DESCRIPTION
This pull request includes significant changes to the build and polling mechanisms in the project. The most important changes involve the removal of the `DoPublishOnly` parameter and its related logic, updates to the polling mechanism in the Blazor components, and modifications to the GitHub Actions workflow.

### Build and Publishing Updates:
* Removed the `DoPublishOnly` parameter and its associated logic from the `BuildParameters` class and various tasks in `cake/Program.cs` [[1]](diffhunk://#diff-3643cd3ef233fca8e097f5b06d3a779d07418e0d9a6711c0366ce437ec28e468L36-L38) [[2]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L68-L73) [[3]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L87-L92) [[4]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L135-L141) [[5]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L176-L181) [[6]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L244-L249).
* Updated the GitHub Actions workflow to conditionally run the cake script and modified the build command to include testing and packaging [[1]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddR35) [[2]](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddL50-R51).

### Polling Mechanism Updates:
* Changed `RenderableComponentBase` and `RenderableComplexComponentBase` classes to be abstract and refactored the polling methods, including the addition of a `ConfigurePolling` method and renaming `RemovePolledElements` to `StopPolling` [[1]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5L26-R26) [[2]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5L41-R41) [[3]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5L54-R81) [[4]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5L81-R95) [[5]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5L98-R128) [[6]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5R168) [[7]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5R177-R187) [[8]](diffhunk://#diff-7df6474dccfb79ce82af43ce4dad7362bf467b82510aa1bdd1d6bde60c1c51e5R220-R226).
* Removed the `SubscribeForPolling` and `UnSubscribeFromPolling` methods from `RenderableContentControl.razor.cs` and updated the component initialization logic to handle polling differently [[1]](diffhunk://#diff-24025595040e8ba2045a337ff41bd4580f354615bed9c3f6765105675ff1353dL153-R157) [[2]](diffhunk://#diff-24025595040e8ba2045a337ff41bd4580f354615bed9c3f6765105675ff1353dL190-L209) [[3]](diffhunk://#diff-24025595040e8ba2045a337ff41bd4580f354615bed9c3f6765105675ff1353dL248) [[4]](diffhunk://#diff-24025595040e8ba2045a337ff41bd4580f354615bed9c3f6765105675ff1353dR280) [[5]](diffhunk://#diff-24025595040e8ba2045a337ff41bd4580f354615bed9c3f6765105675ff1353dL472-L487) [[6]](diffhunk://#diff-24025595040e8ba2045a337ff41bd4580f354615bed9c3f6765105675ff1353dL542).

### Miscellaneous Changes:
* Added a new folder to the Blazor project file (`AXSharp.Presentation.Blazor.Controls.csproj`).
* Fixed a typo in `build.ps1` by removing an extraneous string.
* Added a new launch setting for the build configuration in `launchSettings.json`.