### PR TITLE
Allow multiline pragmas

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertySetterAstNode.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertySetterAstNode.cs
@@ -22,8 +22,18 @@ internal class AddedPropertySetterAstNode : AstNode
         var grammar = context.GetGrammar();
         if (grammar != null)
         {
-            PropertyName = treeNode.GetTheOnlyNode(grammar.AddedPropertyIdentifier.Name).FindTokenAndGetText();
-            InitValue = treeNode.GetTheOnlyNode(grammar.AddedPropertyInitializer.Name).FindTokenAndGetText();
+            PropertyName = treeNode.GetTheOnlyNode(grammar.AddedPropertyIdentifier.Name).FindTokenAndGetText();            
+            var asFreeTextLiteral = InitValue = treeNode.GetTheOnlyNode(grammar.AddedPropertyInitializer.Name).FindTokenAndGetText();
+
+            if (asFreeTextLiteral.StartsWith("\""))
+            {
+                InitValue = $"@{asFreeTextLiteral}";
+            }
+            else
+            {
+                InitValue = asFreeTextLiteral;
+            }
+                        
             MemberName = context.GetContext()?.Declaration?.Name;
         }
     }

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Cs/CsSourceBuilderTests.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Cs/CsSourceBuilderTests.cs
@@ -289,7 +289,13 @@ public abstract partial class CsSourceBuilderTests
         CompareOutputs(GetMethodName());
     }
 
+    [Fact]
+    public void multiline_pragmas()
+    {
+        CompareOutputs(GetMethodName());
+    }
 
+    
     protected abstract ICompilerOptions CompilerOptions { get; }
 
 

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Cs/PragmasExtensionsTests.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Cs/PragmasExtensionsTests.cs
@@ -72,7 +72,7 @@ public class PragmasExtensionsTests
     [Fact]
     public void should_set_property_string()
     {
-        var expected = "someField.AttributeName = \"This is name\";";
+        var expected = "someField.AttributeName = @\"This is name\";";
         var field = NSubstitute.Substitute.For<IFieldDeclaration>();
         field.Name.Returns("someField");
         field.Pragmas.Returns(new ReadOnlyCollection<IPragma>(new IPragma[]
@@ -108,6 +108,28 @@ public class PragmasExtensionsTests
         //        new PragmaMock("#ix-set:AttributeMinimum = 10.5f")
         //    }));
 
+        var actual = field.SetProperties();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void should_set_property_multiline_string()
+    {
+        var expected = "someField.MultilineSet = @\"Line 1 \n Line 2\";";
+        var field = NSubstitute.Substitute.For<IFieldDeclaration>();
+        field.Name.Returns("someField");
+        field.Pragmas.Returns(new ReadOnlyCollection<IPragma>(new IPragma[]
+        {
+            new PragmaMock("#ix-set:MultilineSet =  \"Line 1 \n Line 2\"")
+        }));
+
+        //var field = new FieldMock("someField",
+        //    new ReadOnlyCollection<IPragma>(new IPragma[]
+        //    {
+        //        new PragmaMock("#ix-set:AttributeMinimum = 10.5f")
+        //    }));
+        
         var actual = field.SetProperties();
 
         Assert.Equal(expected, actual);

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/generics.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/generics.g.cs
@@ -441,7 +441,7 @@ namespace GenericsTests
             Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
             PreConstruct(parent, readableTail, symbolTail);
             SomeData = new GenericsTests.SomeTypeToBeGeneric(this, "Shared Header", "SomeData");
-            SomeData.AttributeName = "Shared Header";
+            SomeData.AttributeName = @"Shared Header";
             PostConstruct(parent, readableTail, symbolTail);
         }
 

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/multiline_pragmas.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/multiline_pragmas.g.cs
@@ -1,0 +1,231 @@
+using System;
+using AXSharp.Connector;
+using AXSharp.Connector.ValueTypes;
+using System.Collections.Generic;
+using AXSharp.Connector.Localizations;
+using AXSharp.Abstractions.Presentation;
+
+namespace MultilinePragmas
+{
+    public partial class Extendee2 : AXSharp.Connector.ITwinObject
+    {
+        public OnlinerInt _messge { get; }
+
+        partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
+        partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
+        public Extendee2(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail)
+        {
+            Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
+            this.@SymbolTail = symbolTail;
+            this.@Connector = parent.GetConnector();
+            this.@Parent = parent;
+            HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
+            PreConstruct(parent, readableTail, symbolTail);
+            _messge = @Connector.ConnectorAdapter.AdapterFactory.CreateINT(this, "_messge", "_messge");
+            _messge.PlcTextList = @"[1]:'<#Messenger 1: message text for message code 1#>':'<#Messenger 1: help text for message code 1#>';
+                                    [2]:'<#Messenger 1: message text for message code 2#>':'<#Messenger 1: help text for message code 2#>';
+                                    [3]:'<#Messenger 1: message text for message code 3#>':'<#Messenger 1: help text for message code 3#>';
+                                    [4]:'<#Messenger 1: message text for message code 4#>':'<#Messenger 1: help text for message code 4#>';
+                                    [5]:'<#Messenger 1: message text for message code 5#>':'<#Messenger 1: help text for message code 5#>';
+                                    [6]:'<#Messenger 1: message text for message code 6#>':'<#Messenger 1: help text for message code 6#>';
+                                    [7]:'<#Messenger 1: message text for message code 7#>':'<#Messenger 1: help text for message code 7#>';
+                                    [8]:'<#Messenger 1: message text for message code 8#>':'<#Messenger 1: help text for message code 8#>';
+                                    [9]:'<#Messenger 1: message text for message code 9#>':'<#Messenger 1: help text for message code 9#>';
+                                    [10]:'<#Messenger 1: message text for message code 10#>':'<#Messenger 1: help text for message code 10#>';
+                                    [11]:'<#Messenger 1: message text for message code 11#>':'<#Messenger 1: help text for message code 11#>'";
+            parent.AddChild(this);
+            parent.AddKid(this);
+            PostConstruct(parent, readableTail, symbolTail);
+        }
+
+        public async virtual Task<T> OnlineToPlain<T>()
+        {
+            return await (dynamic)this.OnlineToPlainAsync();
+        }
+
+        public async Task<global::Pocos.MultilinePragmas.Extendee2> OnlineToPlainAsync()
+        {
+            global::Pocos.MultilinePragmas.Extendee2 plain = new global::Pocos.MultilinePragmas.Extendee2();
+            await this.ReadAsync<IgnoreOnPocoOperation>();
+            plain._messge = _messge.LastValue;
+            return plain;
+        }
+
+        [Obsolete("This method should not be used if you indent to access the controllers data. Use `OnlineToPlain` instead.")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public async Task<global::Pocos.MultilinePragmas.Extendee2> _OnlineToPlainNoacAsync()
+        {
+            global::Pocos.MultilinePragmas.Extendee2 plain = new global::Pocos.MultilinePragmas.Extendee2();
+            plain._messge = _messge.LastValue;
+            return plain;
+        }
+
+        [Obsolete("This method should not be used if you indent to access the controllers data. Use `OnlineToPlain` instead.")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected async Task<global::Pocos.MultilinePragmas.Extendee2> _OnlineToPlainNoacAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+            plain._messge = _messge.LastValue;
+            return plain;
+        }
+
+        public async virtual Task PlainToOnline<T>(T plain)
+        {
+            await this.PlainToOnlineAsync((dynamic)plain);
+        }
+
+        public async Task<IEnumerable<ITwinPrimitive>> PlainToOnlineAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+#pragma warning disable CS0612
+            _messge.LethargicWrite(plain._messge);
+#pragma warning restore CS0612
+            return await this.WriteAsync<IgnoreOnPocoOperation>();
+        }
+
+        [Obsolete("This method should not be used if you indent to access the controllers data. Use `PlainToOnline` instead.")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public async Task _PlainToOnlineNoacAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+#pragma warning disable CS0612
+            _messge.LethargicWrite(plain._messge);
+#pragma warning restore CS0612
+        }
+
+        public async virtual Task<T> ShadowToPlain<T>()
+        {
+            return await (dynamic)this.ShadowToPlainAsync();
+        }
+
+        public async Task<global::Pocos.MultilinePragmas.Extendee2> ShadowToPlainAsync()
+        {
+            global::Pocos.MultilinePragmas.Extendee2 plain = new global::Pocos.MultilinePragmas.Extendee2();
+            plain._messge = _messge.Shadow;
+            return plain;
+        }
+
+        protected async Task<global::Pocos.MultilinePragmas.Extendee2> ShadowToPlainAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+            plain._messge = _messge.Shadow;
+            return plain;
+        }
+
+        public async virtual Task PlainToShadow<T>(T plain)
+        {
+            await this.PlainToShadowAsync((dynamic)plain);
+        }
+
+        public async Task<IEnumerable<ITwinPrimitive>> PlainToShadowAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+            _messge.Shadow = plain._messge;
+            return this.RetrievePrimitives();
+        }
+
+        ///<inheritdoc/>
+        public async virtual Task<bool> AnyChangeAsync<T>(T plain)
+        {
+            return await this.DetectsAnyChangeAsync((dynamic)plain);
+        }
+
+        ///<summary>
+        ///Compares if the current plain object has changed from the previous object.This method is used by the framework to determine if the object has changed and needs to be updated.
+        ///[!NOTE] Any member in the hierarchy that is ignored by the compilers (e.g. when CompilerOmitAttribute is used) will not be compared, and therefore will not be detected as changed.
+        ///</summary>
+        public async Task<bool> DetectsAnyChangeAsync(global::Pocos.MultilinePragmas.Extendee2 plain, global::Pocos.MultilinePragmas.Extendee2 latest = null)
+        {
+            if (latest == null)
+                latest = await this._OnlineToPlainNoacAsync();
+            var somethingChanged = false;
+            return await Task.Run(async () =>
+            {
+                if (plain._messge != _messge.LastValue)
+                    somethingChanged = true;
+                plain = latest;
+                return somethingChanged;
+            });
+        }
+
+        public void Poll()
+        {
+            this.RetrievePrimitives().ToList().ForEach(x => x.Poll());
+        }
+
+        public global::Pocos.MultilinePragmas.Extendee2 CreateEmptyPoco()
+        {
+            return new global::Pocos.MultilinePragmas.Extendee2();
+        }
+
+        private IList<AXSharp.Connector.ITwinObject> Children { get; } = new List<AXSharp.Connector.ITwinObject>();
+
+        public IEnumerable<AXSharp.Connector.ITwinObject> GetChildren()
+        {
+            return Children;
+        }
+
+        private IList<AXSharp.Connector.ITwinElement> Kids { get; } = new List<AXSharp.Connector.ITwinElement>();
+
+        public IEnumerable<AXSharp.Connector.ITwinElement> GetKids()
+        {
+            return Kids;
+        }
+
+        private IList<AXSharp.Connector.ITwinPrimitive> ValueTags { get; } = new List<AXSharp.Connector.ITwinPrimitive>();
+
+        public IEnumerable<AXSharp.Connector.ITwinPrimitive> GetValueTags()
+        {
+            return ValueTags;
+        }
+
+        public void AddValueTag(AXSharp.Connector.ITwinPrimitive valueTag)
+        {
+            ValueTags.Add(valueTag);
+        }
+
+        public void AddKid(AXSharp.Connector.ITwinElement kid)
+        {
+            Kids.Add(kid);
+        }
+
+        public void AddChild(AXSharp.Connector.ITwinObject twinObject)
+        {
+            Children.Add(twinObject);
+        }
+
+        protected AXSharp.Connector.Connector @Connector { get; }
+
+        public AXSharp.Connector.Connector GetConnector()
+        {
+            return this.@Connector;
+        }
+
+        public string GetSymbolTail()
+        {
+            return this.SymbolTail;
+        }
+
+        public AXSharp.Connector.ITwinObject GetParent()
+        {
+            return this.@Parent;
+        }
+
+        public string Symbol { get; protected set; }
+
+        private string _attributeName;
+        public System.String AttributeName { get => string.IsNullOrEmpty(_attributeName) ? SymbolTail : _attributeName.Interpolate(this).CleanUpLocalizationTokens(); set => _attributeName = value; }
+
+        public System.String GetAttributeName(System.Globalization.CultureInfo culture)
+        {
+            return this.Translate(_attributeName, culture).Interpolate(this);
+        }
+
+        private string _humanReadable;
+        public string HumanReadable { get => string.IsNullOrEmpty(_humanReadable) ? SymbolTail : _humanReadable.Interpolate(this).CleanUpLocalizationTokens(); set => _humanReadable = value; }
+
+        public System.String GetHumanReadable(System.Globalization.CultureInfo culture)
+        {
+            return this.Translate(_humanReadable, culture);
+        }
+
+        protected System.String @SymbolTail { get; set; }
+        protected AXSharp.Connector.ITwinObject @Parent { get; set; }
+        public AXSharp.Connector.Localizations.Translator Interpreter => global::units.PlcTranslator.Instance;
+    }
+}

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/types_with_property_attributes.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/types_with_property_attributes.g.cs
@@ -23,7 +23,7 @@ namespace TypesWithPropertyAttributes
         partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
         public SomeAddedProperties(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail)
         {
-            Description = "Some added property name value";
+            Description = @"Some added property name value";
             Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
             this.@SymbolTail = symbolTail;
             this.@Connector = parent.GetConnector();
@@ -31,7 +31,7 @@ namespace TypesWithPropertyAttributes
             HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
             PreConstruct(parent, readableTail, symbolTail);
             Counter = @Connector.ConnectorAdapter.AdapterFactory.CreateINT(this, "Pocitadlo", "Counter");
-            Counter.AttributeName = "Pocitadlo";
+            Counter.AttributeName = @"Pocitadlo";
             parent.AddChild(this);
             parent.AddKid(this);
             PostConstruct(parent, readableTail, symbolTail);

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/generics.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/generics.g.cs
@@ -29,7 +29,7 @@ namespace Pocos
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Shared Header")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Shared Header")]
             public GenericsTests.SomeTypeToBeGeneric SomeData { get; set; } = new GenericsTests.SomeTypeToBeGeneric();
         }
     }

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/multiline_pragmas.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/multiline_pragmas.g.cs
@@ -1,0 +1,29 @@
+using System;
+using AXSharp.Abstractions.Presentation;
+using AXSharp.Connector;
+
+namespace Pocos
+{
+    namespace MultilinePragmas
+    {
+        public partial class Extendee2 : AXSharp.Connector.IPlain
+        {
+            public Extendee2()
+            {
+            }
+
+            [AXSharp.Connector.AddedPropertiesAttribute("PlcTextList", @"[1]:'<#Messenger 1: message text for message code 1#>':'<#Messenger 1: help text for message code 1#>';
+                                    [2]:'<#Messenger 1: message text for message code 2#>':'<#Messenger 1: help text for message code 2#>';
+                                    [3]:'<#Messenger 1: message text for message code 3#>':'<#Messenger 1: help text for message code 3#>';
+                                    [4]:'<#Messenger 1: message text for message code 4#>':'<#Messenger 1: help text for message code 4#>';
+                                    [5]:'<#Messenger 1: message text for message code 5#>':'<#Messenger 1: help text for message code 5#>';
+                                    [6]:'<#Messenger 1: message text for message code 6#>':'<#Messenger 1: help text for message code 6#>';
+                                    [7]:'<#Messenger 1: message text for message code 7#>':'<#Messenger 1: help text for message code 7#>';
+                                    [8]:'<#Messenger 1: message text for message code 8#>':'<#Messenger 1: help text for message code 8#>';
+                                    [9]:'<#Messenger 1: message text for message code 9#>':'<#Messenger 1: help text for message code 9#>';
+                                    [10]:'<#Messenger 1: message text for message code 10#>':'<#Messenger 1: help text for message code 10#>';
+                                    [11]:'<#Messenger 1: message text for message code 11#>':'<#Messenger 1: help text for message code 11#>'")]
+            public Int16 _messge { get; set; }
+        }
+    }
+}

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/types_with_property_attributes.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/types_with_property_attributes.g.cs
@@ -6,14 +6,14 @@ namespace Pocos
 {
     namespace TypesWithPropertyAttributes
     {
-        [AXSharp.Connector.AddedPropertiesAttribute("Description", "Some added property name value")]
+        [AXSharp.Connector.AddedPropertiesAttribute("Description", @"Some added property name value")]
         public partial class SomeAddedProperties : AXSharp.Connector.IPlain
         {
             public SomeAddedProperties()
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Pocitadlo")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Pocitadlo")]
             public Int16 Counter { get; set; }
         }
     }

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/units.csproj
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/units.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AXSharp.Abstractions" Version="0.23.0-388-allow-multiline-pragmas.364" />
+		<PackageReference Include="AXSharp.Connector" Version="0.23.0-388-allow-multiline-pragmas.364" />
+	</ItemGroup>
+
+	<ItemGroup>
+    	<Compile Include=".g\**" />
+  	</ItemGroup>
+
+	<ItemGroup>
+		<Folder Include=".meta\" />
+		<Content Include=".meta\**" />
+	</ItemGroup>
+</Project>

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/generics.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/generics.g.cs
@@ -441,7 +441,7 @@ namespace GenericsTests
             Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
             PreConstruct(parent, readableTail, symbolTail);
             SomeData = new GenericsTests.SomeTypeToBeGeneric(this, "Shared Header", "SomeData");
-            SomeData.AttributeName = "Shared Header";
+            SomeData.AttributeName = @"Shared Header";
             PostConstruct(parent, readableTail, symbolTail);
         }
 

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/multiline_pragmas.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/multiline_pragmas.g.cs
@@ -1,0 +1,231 @@
+using System;
+using AXSharp.Connector;
+using AXSharp.Connector.ValueTypes;
+using System.Collections.Generic;
+using AXSharp.Connector.Localizations;
+using AXSharp.Abstractions.Presentation;
+
+namespace MultilinePragmas
+{
+    public partial class Extendee2 : AXSharp.Connector.ITwinObject
+    {
+        public OnlinerInt _messge { get; }
+
+        partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
+        partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
+        public Extendee2(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail)
+        {
+            Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
+            this.@SymbolTail = symbolTail;
+            this.@Connector = parent.GetConnector();
+            this.@Parent = parent;
+            HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
+            PreConstruct(parent, readableTail, symbolTail);
+            _messge = @Connector.ConnectorAdapter.AdapterFactory.CreateINT(this, "_messge", "_messge");
+            _messge.PlcTextList = @"[1]:'<#Messenger 1: message text for message code 1#>':'<#Messenger 1: help text for message code 1#>';
+                                    [2]:'<#Messenger 1: message text for message code 2#>':'<#Messenger 1: help text for message code 2#>';
+                                    [3]:'<#Messenger 1: message text for message code 3#>':'<#Messenger 1: help text for message code 3#>';
+                                    [4]:'<#Messenger 1: message text for message code 4#>':'<#Messenger 1: help text for message code 4#>';
+                                    [5]:'<#Messenger 1: message text for message code 5#>':'<#Messenger 1: help text for message code 5#>';
+                                    [6]:'<#Messenger 1: message text for message code 6#>':'<#Messenger 1: help text for message code 6#>';
+                                    [7]:'<#Messenger 1: message text for message code 7#>':'<#Messenger 1: help text for message code 7#>';
+                                    [8]:'<#Messenger 1: message text for message code 8#>':'<#Messenger 1: help text for message code 8#>';
+                                    [9]:'<#Messenger 1: message text for message code 9#>':'<#Messenger 1: help text for message code 9#>';
+                                    [10]:'<#Messenger 1: message text for message code 10#>':'<#Messenger 1: help text for message code 10#>';
+                                    [11]:'<#Messenger 1: message text for message code 11#>':'<#Messenger 1: help text for message code 11#>'";
+            parent.AddChild(this);
+            parent.AddKid(this);
+            PostConstruct(parent, readableTail, symbolTail);
+        }
+
+        public async virtual Task<T> OnlineToPlain<T>()
+        {
+            return await (dynamic)this.OnlineToPlainAsync();
+        }
+
+        public async Task<global::Pocos.MultilinePragmas.Extendee2> OnlineToPlainAsync()
+        {
+            global::Pocos.MultilinePragmas.Extendee2 plain = new global::Pocos.MultilinePragmas.Extendee2();
+            await this.ReadAsync<IgnoreOnPocoOperation>();
+            plain._messge = _messge.LastValue;
+            return plain;
+        }
+
+        [Obsolete("This method should not be used if you indent to access the controllers data. Use `OnlineToPlain` instead.")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public async Task<global::Pocos.MultilinePragmas.Extendee2> _OnlineToPlainNoacAsync()
+        {
+            global::Pocos.MultilinePragmas.Extendee2 plain = new global::Pocos.MultilinePragmas.Extendee2();
+            plain._messge = _messge.LastValue;
+            return plain;
+        }
+
+        [Obsolete("This method should not be used if you indent to access the controllers data. Use `OnlineToPlain` instead.")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected async Task<global::Pocos.MultilinePragmas.Extendee2> _OnlineToPlainNoacAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+            plain._messge = _messge.LastValue;
+            return plain;
+        }
+
+        public async virtual Task PlainToOnline<T>(T plain)
+        {
+            await this.PlainToOnlineAsync((dynamic)plain);
+        }
+
+        public async Task<IEnumerable<ITwinPrimitive>> PlainToOnlineAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+#pragma warning disable CS0612
+            _messge.LethargicWrite(plain._messge);
+#pragma warning restore CS0612
+            return await this.WriteAsync<IgnoreOnPocoOperation>();
+        }
+
+        [Obsolete("This method should not be used if you indent to access the controllers data. Use `PlainToOnline` instead.")]
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public async Task _PlainToOnlineNoacAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+#pragma warning disable CS0612
+            _messge.LethargicWrite(plain._messge);
+#pragma warning restore CS0612
+        }
+
+        public async virtual Task<T> ShadowToPlain<T>()
+        {
+            return await (dynamic)this.ShadowToPlainAsync();
+        }
+
+        public async Task<global::Pocos.MultilinePragmas.Extendee2> ShadowToPlainAsync()
+        {
+            global::Pocos.MultilinePragmas.Extendee2 plain = new global::Pocos.MultilinePragmas.Extendee2();
+            plain._messge = _messge.Shadow;
+            return plain;
+        }
+
+        protected async Task<global::Pocos.MultilinePragmas.Extendee2> ShadowToPlainAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+            plain._messge = _messge.Shadow;
+            return plain;
+        }
+
+        public async virtual Task PlainToShadow<T>(T plain)
+        {
+            await this.PlainToShadowAsync((dynamic)plain);
+        }
+
+        public async Task<IEnumerable<ITwinPrimitive>> PlainToShadowAsync(global::Pocos.MultilinePragmas.Extendee2 plain)
+        {
+            _messge.Shadow = plain._messge;
+            return this.RetrievePrimitives();
+        }
+
+        ///<inheritdoc/>
+        public async virtual Task<bool> AnyChangeAsync<T>(T plain)
+        {
+            return await this.DetectsAnyChangeAsync((dynamic)plain);
+        }
+
+        ///<summary>
+        ///Compares if the current plain object has changed from the previous object.This method is used by the framework to determine if the object has changed and needs to be updated.
+        ///[!NOTE] Any member in the hierarchy that is ignored by the compilers (e.g. when CompilerOmitAttribute is used) will not be compared, and therefore will not be detected as changed.
+        ///</summary>
+        public async Task<bool> DetectsAnyChangeAsync(global::Pocos.MultilinePragmas.Extendee2 plain, global::Pocos.MultilinePragmas.Extendee2 latest = null)
+        {
+            if (latest == null)
+                latest = await this._OnlineToPlainNoacAsync();
+            var somethingChanged = false;
+            return await Task.Run(async () =>
+            {
+                if (plain._messge != _messge.LastValue)
+                    somethingChanged = true;
+                plain = latest;
+                return somethingChanged;
+            });
+        }
+
+        public void Poll()
+        {
+            this.RetrievePrimitives().ToList().ForEach(x => x.Poll());
+        }
+
+        public global::Pocos.MultilinePragmas.Extendee2 CreateEmptyPoco()
+        {
+            return new global::Pocos.MultilinePragmas.Extendee2();
+        }
+
+        private IList<AXSharp.Connector.ITwinObject> Children { get; } = new List<AXSharp.Connector.ITwinObject>();
+
+        public IEnumerable<AXSharp.Connector.ITwinObject> GetChildren()
+        {
+            return Children;
+        }
+
+        private IList<AXSharp.Connector.ITwinElement> Kids { get; } = new List<AXSharp.Connector.ITwinElement>();
+
+        public IEnumerable<AXSharp.Connector.ITwinElement> GetKids()
+        {
+            return Kids;
+        }
+
+        private IList<AXSharp.Connector.ITwinPrimitive> ValueTags { get; } = new List<AXSharp.Connector.ITwinPrimitive>();
+
+        public IEnumerable<AXSharp.Connector.ITwinPrimitive> GetValueTags()
+        {
+            return ValueTags;
+        }
+
+        public void AddValueTag(AXSharp.Connector.ITwinPrimitive valueTag)
+        {
+            ValueTags.Add(valueTag);
+        }
+
+        public void AddKid(AXSharp.Connector.ITwinElement kid)
+        {
+            Kids.Add(kid);
+        }
+
+        public void AddChild(AXSharp.Connector.ITwinObject twinObject)
+        {
+            Children.Add(twinObject);
+        }
+
+        protected AXSharp.Connector.Connector @Connector { get; }
+
+        public AXSharp.Connector.Connector GetConnector()
+        {
+            return this.@Connector;
+        }
+
+        public string GetSymbolTail()
+        {
+            return this.SymbolTail;
+        }
+
+        public AXSharp.Connector.ITwinObject GetParent()
+        {
+            return this.@Parent;
+        }
+
+        public string Symbol { get; protected set; }
+
+        private string _attributeName;
+        public System.String AttributeName { get => string.IsNullOrEmpty(_attributeName) ? SymbolTail : _attributeName.Interpolate(this).CleanUpLocalizationTokens(); set => _attributeName = value; }
+
+        public System.String GetAttributeName(System.Globalization.CultureInfo culture)
+        {
+            return this.Translate(_attributeName, culture).Interpolate(this);
+        }
+
+        private string _humanReadable;
+        public string HumanReadable { get => string.IsNullOrEmpty(_humanReadable) ? SymbolTail : _humanReadable.Interpolate(this).CleanUpLocalizationTokens(); set => _humanReadable = value; }
+
+        public System.String GetHumanReadable(System.Globalization.CultureInfo culture)
+        {
+            return this.Translate(_humanReadable, culture);
+        }
+
+        protected System.String @SymbolTail { get; set; }
+        protected AXSharp.Connector.ITwinObject @Parent { get; set; }
+        public AXSharp.Connector.Localizations.Translator Interpreter => global::units.PlcTranslator.Instance;
+    }
+}

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/types_with_property_attributes.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/types_with_property_attributes.g.cs
@@ -23,7 +23,7 @@ namespace TypesWithPropertyAttributes
         partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
         public SomeAddedProperties(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail)
         {
-            Description = "Some added property name value";
+            Description = @"Some added property name value";
             Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
             this.@SymbolTail = symbolTail;
             this.@Connector = parent.GetConnector();
@@ -31,7 +31,7 @@ namespace TypesWithPropertyAttributes
             HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
             PreConstruct(parent, readableTail, symbolTail);
             Counter = @Connector.ConnectorAdapter.AdapterFactory.CreateINT(this, "Pocitadlo", "Counter");
-            Counter.AttributeName = "Pocitadlo";
+            Counter.AttributeName = @"Pocitadlo";
             parent.AddChild(this);
             parent.AddKid(this);
             PostConstruct(parent, readableTail, symbolTail);

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/POCO/generics.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/POCO/generics.g.cs
@@ -29,7 +29,7 @@ namespace Pocos
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Shared Header")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Shared Header")]
             public GenericsTests.SomeTypeToBeGeneric SomeData { get; set; } = new GenericsTests.SomeTypeToBeGeneric();
         }
     }

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/POCO/multiline_pragmas.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/POCO/multiline_pragmas.g.cs
@@ -1,0 +1,29 @@
+using System;
+using AXSharp.Abstractions.Presentation;
+using AXSharp.Connector;
+
+namespace Pocos
+{
+    namespace MultilinePragmas
+    {
+        public partial class Extendee2 : AXSharp.Connector.IPlain
+        {
+            public Extendee2()
+            {
+            }
+
+            [AXSharp.Connector.AddedPropertiesAttribute("PlcTextList", @"[1]:'<#Messenger 1: message text for message code 1#>':'<#Messenger 1: help text for message code 1#>';
+                                    [2]:'<#Messenger 1: message text for message code 2#>':'<#Messenger 1: help text for message code 2#>';
+                                    [3]:'<#Messenger 1: message text for message code 3#>':'<#Messenger 1: help text for message code 3#>';
+                                    [4]:'<#Messenger 1: message text for message code 4#>':'<#Messenger 1: help text for message code 4#>';
+                                    [5]:'<#Messenger 1: message text for message code 5#>':'<#Messenger 1: help text for message code 5#>';
+                                    [6]:'<#Messenger 1: message text for message code 6#>':'<#Messenger 1: help text for message code 6#>';
+                                    [7]:'<#Messenger 1: message text for message code 7#>':'<#Messenger 1: help text for message code 7#>';
+                                    [8]:'<#Messenger 1: message text for message code 8#>':'<#Messenger 1: help text for message code 8#>';
+                                    [9]:'<#Messenger 1: message text for message code 9#>':'<#Messenger 1: help text for message code 9#>';
+                                    [10]:'<#Messenger 1: message text for message code 10#>':'<#Messenger 1: help text for message code 10#>';
+                                    [11]:'<#Messenger 1: message text for message code 11#>':'<#Messenger 1: help text for message code 11#>'")]
+            public Int16 _messge { get; set; }
+        }
+    }
+}

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/POCO/types_with_property_attributes.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/POCO/types_with_property_attributes.g.cs
@@ -6,14 +6,14 @@ namespace Pocos
 {
     namespace TypesWithPropertyAttributes
     {
-        [AXSharp.Connector.AddedPropertiesAttribute("Description", "Some added property name value")]
+        [AXSharp.Connector.AddedPropertiesAttribute("Description", @"Some added property name value")]
         public partial class SomeAddedProperties : AXSharp.Connector.IPlain
         {
             public SomeAddedProperties()
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Pocitadlo")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Pocitadlo")]
             public Int16 Counter { get; set; }
         }
     }

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/units.csproj
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/units.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AXSharp.Abstractions" Version="0.23.0-388-allow-multiline-pragmas.364" />
+		<PackageReference Include="AXSharp.Connector" Version="0.23.0-388-allow-multiline-pragmas.364" />
+	</ItemGroup>
+
+	<ItemGroup>
+    	<Compile Include=".g\**" />
+  	</ItemGroup>
+
+	<ItemGroup>
+		<Folder Include=".meta\" />
+		<Content Include=".meta\**" />
+	</ItemGroup>
+</Project>

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/src/multiline_pragmas.st
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/src/multiline_pragmas.st
@@ -1,0 +1,20 @@
+// GENERIC
+NAMESPACE MultilinePragmas
+   {S7.extern=ReadWrite}
+   CLASS PUBLIC Extendee2 EXTENDS Extender
+        VAR PUBLIC            
+            {#ix-set:PlcTextList = "[1]:'<#Messenger 1: message text for message code 1#>':'<#Messenger 1: help text for message code 1#>';
+                                    [2]:'<#Messenger 1: message text for message code 2#>':'<#Messenger 1: help text for message code 2#>';
+                                    [3]:'<#Messenger 1: message text for message code 3#>':'<#Messenger 1: help text for message code 3#>';
+                                    [4]:'<#Messenger 1: message text for message code 4#>':'<#Messenger 1: help text for message code 4#>';
+                                    [5]:'<#Messenger 1: message text for message code 5#>':'<#Messenger 1: help text for message code 5#>';
+                                    [6]:'<#Messenger 1: message text for message code 6#>':'<#Messenger 1: help text for message code 6#>';
+                                    [7]:'<#Messenger 1: message text for message code 7#>':'<#Messenger 1: help text for message code 7#>';
+                                    [8]:'<#Messenger 1: message text for message code 8#>':'<#Messenger 1: help text for message code 8#>';
+                                    [9]:'<#Messenger 1: message text for message code 9#>':'<#Messenger 1: help text for message code 9#>';
+                                    [10]:'<#Messenger 1: message text for message code 10#>':'<#Messenger 1: help text for message code 10#>';
+                                    [11]:'<#Messenger 1: message text for message code 11#>':'<#Messenger 1: help text for message code 11#>'"}
+            _messge : INT;        
+        END_VAR
+   END_CLASS
+END_NAMESPACE    


### PR DESCRIPTION
This pull request introduces support for multiline pragmas and updates various test cases and sample files to accommodate this new feature. The most important changes include modifications to handle multiline strings in property setters, updates to test cases to ensure correct handling of multiline pragmas, and adjustments to sample files to reflect these changes.

Support for multiline pragmas:

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Pragmas/PragmaParser/Ast/AddedPropertySetterAstNode.cs`](diffhunk://#diff-beab819bed2188281de93ef64f71e22a535512ad56bbc17d862d9e12f5ca10a4L26-R36): Enhanced the `Init` method to handle multiline strings by checking if the string starts with a quote and adjusting the initialization value accordingly.

Updates to test cases:

* [`src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Cs/CsSourceBuilderTests.cs`](diffhunk://#diff-a2351b244e5deae2c72f6fe7dab3df7cbb6ef3a4b2b95af0e96b4356280da366R292-R297): Added a new test case `multiline_pragmas` to verify the correct handling of multiline pragmas.
* [`src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Cs/PragmasExtensionsTests.cs`](diffhunk://#diff-4dbe4521bf15820267ae0eb1189a191f96ccf0ccb852abd9f6bd92b72eb9ebafR116-R137): Added a new test case `should_set_property_multiline_string` to ensure multiline strings are set correctly.

Adjustments to sample files:

* [`src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/multiline_pragmas.g.cs`](diffhunk://#diff-ccf62587b0fa5b2ef789356470eb315d9c60d9b4bd1318cc24261fe4024e573fR1-R231): Added a new sample file to demonstrate the usage of multiline pragmas in generated code.
* [`src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/POCO/multiline_pragmas.g.cs`](diffhunk://#diff-0e6027fd61839ddd24320b9a3f2d55391db59dc4be2721c1b3ddc626f7e9ffc3R1-R29): Added a new sample POCO file to show how multiline pragmas are represented in plain objects.

Project configuration updates:

* [`src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/units.csproj`](diffhunk://#diff-5fbf5efc166cb87e57654248653a107c451df79a0461014d46ff93009b928862R1-R21): Updated the project file to include necessary package references and enable support for multiple target frameworks.


closes #388