### PR TITLE
Missing types in smodel

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 0.23.0
+next-version: 0.24.0
 branches:
   main:
     regex: ^master$|^main$

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -6,10 +6,12 @@
 // Third party licenses: https://github.com/inxton/axsharp/blob/master/notices.md
 
 using AX.ST.Semantic;
+using AX.ST.Semantic.Model;
 using AX.ST.Semantic.Model.Declarations;
 using AX.ST.Semantic.Model.Declarations.Types;
 using AXSharp.Compiler.Core;
 using AXSharp.Compiler.Cs.Exceptions;
+using AXSharp.Compiler.Cs.Helpers;
 using AXSharp.Connector;
 
 namespace AXSharp.Compiler.Cs;
@@ -26,13 +28,156 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder signature</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static bool IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration qualifiedName) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
-        return field.AccessModifier == AccessModifier.Public 
-               && field.IsEligibleForTranspile(sourceBuilder)
-               && !IsToBeOmitted(field, sourceBuilder, coBuilder);
+        var eligibility = field.IsEligibleForTranspile(sourceBuilder);
+        var isEligible = (field.AccessModifier == AccessModifier.Public
+                            && eligibility.isEligibe
+                            && !IsToBeOmitted(field, sourceBuilder, coBuilder));
+
+        return (isEligible, eligibility.qualifiedName);
+    }
+    
+
+    /// <summary>
+    /// Finds type declaration.
+    /// </summary>
+    /// <param name="compilation">Compilation object</param>
+    /// <param name="typeAccess">Required type</param>
+    /// <returns>Required type if found.</returns>
+    public static ITypeDeclaration FindTypeDeclaration(this Compilation compilation, AX.ST.Semantic.Model.ISemanticTypeAccess? typeAccess)
+    {
+        // This is to resolve fully qualified type name when the type cannot be determined propeprly form the semantic tree.
+        // TODO: This workaround should be removed once we can properly use project dependencies in the stc.
+        if (typeAccess == null)
+        {
+            return null;
+        }
+
+        var fullyQualified = compilation.GetSemanticTree().Types.DistinctBy(p => p.FullyQualifiedName).Where(p => p.FullyQualifiedName == typeAccess.Type.FullyQualifiedName).FirstOrDefault();
+
+        if (fullyQualified != null)
+        {
+            return fullyQualified;
+        }
+
+        var candidates = compilation.GetSemanticTree().Types.DistinctBy(p => p.FullyQualifiedName).Where(p => p.Name == typeAccess.TypeSymbol.Name);
+        if (candidates.Count() == 1)
+        {
+            return candidates.First();
+        }
+
+        if (candidates.Count() == 0)
+        {
+            Log.Logger.Warning($"Type '{typeAccess?.ToString()}' not found in the semantic tree.");
+        }
+
+        if (candidates.Count() > 1)
+        {
+            Log.Logger.Warning($"Multiple types found for '{typeAccess?.ToString()}' in the semantic tree. You may need to fully qualify the declaration.");
+        }
+
+        return null;
     }
 
+    public static ITypeDeclaration FindTypeDeclaration(this Compilation compilation, IDeclaration? typeAccess)
+    {
+        // This is to resolve fully qualified type name when the type cannot be determined propeprly form the semantic tree.
+        // TODO: This workaround should be removed once we can properly use project dependencies in the stc.
+        if (typeAccess == null)
+        {
+            return null;
+        }
+
+        var fullyQualified = compilation.GetSemanticTree().Types.DistinctBy(p => p.FullyQualifiedName).Where(p => p.FullyQualifiedName == typeAccess.Type.FullyQualifiedName).FirstOrDefault();
+
+        if (fullyQualified != null)
+        {
+            return fullyQualified;
+        }
+
+        var candidates = compilation.GetSemanticTree().Types.DistinctBy(p => p.FullyQualifiedName).Where(p => p.Name == typeAccess.Name);
+        if (candidates.Count() == 1)
+        {
+            return candidates.First();
+        }
+
+        if (candidates.Count() == 0)
+        {
+            Log.Logger.Warning($"Type '{typeAccess?.ToString()}' not found in the semantic tree.");
+        }
+
+        if (candidates.Count() > 1)
+        {
+            Log.Logger.Warning($"Multiple types found for '{typeAccess?.ToString()}' in the semantic tree. You may need to fully qualify the declaration.");
+        }
+
+        return null;
+    }
+
+    public static string? DetermineFullyQualifiedName(this AX.ST.Semantic.Model.ISemanticTypeAccess declaration, Compilation compilation)
+    {
+        return compilation.FindTypeDeclaration(declaration)?.FullyQualifiedName;
+    }
+
+    public static void AddFullyQualifiedName(this ISemanticTypeAccess declaration, Compilation compilation, Action<string, string> updateCode)
+    {
+        if (declaration.Type.Kind == DeclarationKind.Ambiguous)
+        {
+            var fqn = declaration.DetermineFullyQualifiedName(compilation);
+            if (fqn != null)
+            {
+                updateCode(fqn, " ");
+            }
+        }
+        else
+        {
+            updateCode(declaration.Type.FullyQualifiedName, " ");
+        }
+    }
+
+    public static void AddFullyQualifiedName(this IDeclaration declaration, Compilation compilation, Action<string, string> updateCode)
+    {
+        if (declaration.Type.Kind == DeclarationKind.Ambiguous)
+        {
+            var fqn = declaration.DetermineFullyQualifiedName(compilation);
+            if (fqn != null)
+            {
+                updateCode(fqn, " ");
+            }
+        }
+        else
+        {
+            updateCode(declaration.Type.FullyQualifiedName, " ");
+        }
+    }
+
+    public static string? DetermineFullyQualifiedName(this IDeclaration declaration, Compilation compilation)
+    {
+        return compilation.FindTypeDeclaration(declaration)?.FullyQualifiedName;
+    }
+
+    /// <summary>
+    /// Determines fully qualified name of the declaration.
+    /// </summary>
+    /// <param name="declaration">Field declaration</param>
+    /// <param name="compilation">Compilation object.</param>
+    /// <returns>Fully qualified name of the declaration.</returns>
+    public static string? DetermineFullyQualifiedName(this IFieldDeclaration declaration, Compilation compilation)
+    {
+        return compilation.FindTypeDeclaration(declaration.TypeAccess)?.FullyQualifiedName;
+    }
+
+    /// <summary>
+    /// Determines fully qualified name of the declaration.
+    /// </summary>
+    /// <param name="declaration">Variable declaration</param>
+    /// <param name="compilation">Compilation object.</param>
+    /// <returns>Fully qualified name of the declaration.</returns>
+    public static string? DetermineFullyQualifiedName(this IVariableDeclaration declaration, Compilation compilation)
+    {
+        return compilation.FindTypeDeclaration(declaration.TypeAccess)?.FullyQualifiedName;
+    }
 
     private static bool IsToBeOmitted(this IStorageDeclaration fieldDeclaration, ISourceBuilder sourceBuilder, string coBuilder)
     {
@@ -78,9 +223,10 @@ public static class SemanticsHelpers
     /// <param name="fieldDeclaration"></param>
     /// <param name="sourceBuilder"></param>
     /// <returns>True when the type is eligible</returns>
-    public static bool IsEligibleForTranspile(this IFieldDeclaration fieldDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration qualifiedName) IsEligibleForTranspile(this IFieldDeclaration fieldDeclaration, ISourceBuilder sourceBuilder)
     {
         var type = fieldDeclaration.Type;
+        var fullyQualified = sourceBuilder.Compilation.FindTypeDeclaration(fieldDeclaration.TypeAccess);
         var isEligible = !(type is IReferenceTypeDeclaration)
                 &&
                 fieldDeclaration.IsAvailableForComm(sourceBuilder)
@@ -89,15 +235,14 @@ public static class SemanticsHelpers
                  type is IStringTypeDeclaration ||
                  type is IStructuredTypeDeclaration ||
                  type is INamedValueTypeDeclaration ||
-                 sourceBuilder.Compilation.GetSemanticTree().Types.Any(p =>
-                     p.FullyQualifiedName == type.FullyQualifiedName));
+                 fullyQualified != null);
 
-            if(!isEligible) 
-            {
-                Log.Logger.Debug($"Field '{fieldDeclaration.Name}' of type '{fieldDeclaration.Type.FullyQualifiedName}' is not eligible for transpile");
-            }
+        if (!isEligible)
+        {
+            Log.Logger.Debug($"Field '{fieldDeclaration.Name}' of type '{fieldDeclaration.Type.FullyQualifiedName}' is not eligible for transpile");
+        }
 
-        return isEligible;
+        return (isEligible, fullyQualified);
     }
 
     /// <summary>
@@ -106,9 +251,10 @@ public static class SemanticsHelpers
     /// <param name="variableDeclaration"></param>
     /// <param name="sourceBuilder"></param>
     /// <returns>True when the type is eligible</returns>
-    public static bool IsEligibleForTranspile(this IVariableDeclaration variableDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsEligibleForTranspile(this IVariableDeclaration variableDeclaration, ISourceBuilder sourceBuilder)
     {
         var type = variableDeclaration.Type;
+        var declaration = sourceBuilder.Compilation.FindTypeDeclaration(variableDeclaration.TypeAccess);
         var isEligible = !(type is IReferenceTypeDeclaration)
                &&
                variableDeclaration.IsAvailableForComm(sourceBuilder)
@@ -117,15 +263,14 @@ public static class SemanticsHelpers
                 type is IStringTypeDeclaration ||
                 type is IStructuredTypeDeclaration ||
                 type is INamedValueTypeDeclaration ||
-                sourceBuilder.Compilation.GetSemanticTree().Types.Any(p =>
-                    p.FullyQualifiedName == type.FullyQualifiedName));
+                declaration != null);
 
         if (!isEligible)
         {
             Log.Logger.Debug($"Variable '{variableDeclaration.Name}' of type '{variableDeclaration.Type.FullyQualifiedName}' is not eligible for transpile");
         }
 
-        return isEligible;
+        return (isEligible, declaration);
     }
 
 
@@ -135,10 +280,10 @@ public static class SemanticsHelpers
     /// <param name="arrayTypeDeclaration"></param>
     /// <param name="sourceBuilder">Source builder</param>
     /// <returns></returns>
-    public static bool IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
     {
         var singleDimensionalArray = arrayTypeDeclaration.Dimensions.Count == 1;
-
+        var declaration = sourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess);
         var isEligibleType = !(arrayTypeDeclaration.ElementTypeAccess.Type is IReferenceTypeDeclaration)
                              &&
                              arrayTypeDeclaration.IsAvailableForComm(sourceBuilder)
@@ -147,10 +292,9 @@ public static class SemanticsHelpers
                               arrayTypeDeclaration.ElementTypeAccess.Type is IStringTypeDeclaration ||
                               arrayTypeDeclaration.ElementTypeAccess.Type is IStructuredTypeDeclaration ||
                               arrayTypeDeclaration.ElementTypeAccess.Type is INamedValueTypeDeclaration ||
-                              sourceBuilder.Compilation.GetSemanticTree().Types.Any(p =>
-                                  p.FullyQualifiedName == arrayTypeDeclaration.ElementTypeAccess.Type.FullyQualifiedName));
+                              declaration != null);
 
-        return isEligibleType && singleDimensionalArray;
+        return (isEligibleType && singleDimensionalArray, declaration);
 
     }
 
@@ -162,11 +306,14 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Co-builder signature (e.g. POCO, Onliner, etc.)</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static bool IsMemberEligibleForTranspile(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForTranspile(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
-        return variable.IsInGlobalMemory 
-               && variable.IsEligibleForTranspile(sourceBuilder)
-               && !IsToBeOmitted(variable, sourceBuilder, coBuilder); 
+        var eligibility = variable.IsEligibleForTranspile(sourceBuilder);
+        var eligible = variable.IsInGlobalMemory
+               && eligibility.isEligibe
+               && !IsToBeOmitted(variable, sourceBuilder, coBuilder);
+
+        return (eligible, eligibility.qualifiedName);
     }
 
     /// <summary>
@@ -176,9 +323,10 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static bool IsMemberEligibleForConstructor(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForConstructor(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
-        return field.AccessModifier == AccessModifier.Public && field.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
+        var eligibility = field.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
+        return ((field.AccessModifier == AccessModifier.Public && eligibility.isEligibe), eligibility.qualifiedName);
     }
 
     /// <summary>
@@ -188,7 +336,7 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static bool IsMemberEligibleForConstructor(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForConstructor(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         return variable.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
     }
@@ -243,13 +391,13 @@ public static class SemanticsHelpers
 
         return eCommAccessibility.None;
     }
-    
 
-    
 
-    
 
-    public static bool IsMemberEligibleForConstructor(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
+
+
+
+    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForConstructor(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
     {
         return IsEligibleForTranspile(arrayTypeDeclaration, sourceBuilder);
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -28,7 +28,7 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder signature</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligibe, ITypeDeclaration eligibleType) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligible, ITypeDeclaration eligibleType) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         var eligibility = field.IsEligibleForTranspile(sourceBuilder);
         var isEligible = (field.AccessModifier == AccessModifier.Public

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -335,7 +335,7 @@ public static class SemanticsHelpers
     public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForConstructor(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         var eligibility = field.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
-        return ((field.AccessModifier == AccessModifier.Public && eligibility.isEligibe), eligibility.eligibleType);
+        return ((field.AccessModifier == AccessModifier.Public && eligibility.isEligible), eligibility.eligibleType);
     }
 
     /// <summary>

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -28,14 +28,14 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder signature</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligibe, ITypeDeclaration qualifiedName) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration eligibleType) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         var eligibility = field.IsEligibleForTranspile(sourceBuilder);
         var isEligible = (field.AccessModifier == AccessModifier.Public
                             && eligibility.isEligibe
                             && !IsToBeOmitted(field, sourceBuilder, coBuilder));
 
-        return (isEligible, eligibility.qualifiedName);
+        return (isEligible, eligibility.eligibleType);
     }
     
 
@@ -47,6 +47,15 @@ public static class SemanticsHelpers
     /// <returns>Required type if found.</returns>
     public static ITypeDeclaration FindTypeDeclaration(this Compilation compilation, AX.ST.Semantic.Model.ISemanticTypeAccess? typeAccess)
     {
+        if (typeAccess == null)
+            return null;
+
+        if (typeAccess.Type is IScalarTypeDeclaration
+            || typeAccess.Type is IStringTypeDeclaration)
+        {
+            return typeAccess.Type;
+        }
+
         // This is to resolve fully qualified type name when the type cannot be determined propeprly form the semantic tree.
         // TODO: This workaround should be removed once we can properly use project dependencies in the stc.
         if (typeAccess == null)
@@ -223,7 +232,7 @@ public static class SemanticsHelpers
     /// <param name="fieldDeclaration"></param>
     /// <param name="sourceBuilder"></param>
     /// <returns>True when the type is eligible</returns>
-    public static (bool isEligibe, ITypeDeclaration qualifiedName) IsEligibleForTranspile(this IFieldDeclaration fieldDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration eligibleType) IsEligibleForTranspile(this IFieldDeclaration fieldDeclaration, ISourceBuilder sourceBuilder)
     {
         var type = fieldDeclaration.Type;
         var fullyQualified = sourceBuilder.Compilation.FindTypeDeclaration(fieldDeclaration.TypeAccess);
@@ -251,7 +260,7 @@ public static class SemanticsHelpers
     /// <param name="variableDeclaration"></param>
     /// <param name="sourceBuilder"></param>
     /// <returns>True when the type is eligible</returns>
-    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsEligibleForTranspile(this IVariableDeclaration variableDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IVariableDeclaration variableDeclaration, ISourceBuilder sourceBuilder)
     {
         var type = variableDeclaration.Type;
         var declaration = sourceBuilder.Compilation.FindTypeDeclaration(variableDeclaration.TypeAccess);
@@ -280,7 +289,7 @@ public static class SemanticsHelpers
     /// <param name="arrayTypeDeclaration"></param>
     /// <param name="sourceBuilder">Source builder</param>
     /// <returns></returns>
-    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
     {
         var singleDimensionalArray = arrayTypeDeclaration.Dimensions.Count == 1;
         var declaration = sourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess);
@@ -306,14 +315,14 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Co-builder signature (e.g. POCO, Onliner, etc.)</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForTranspile(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForTranspile(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         var eligibility = variable.IsEligibleForTranspile(sourceBuilder);
         var eligible = variable.IsInGlobalMemory
                && eligibility.isEligibe
                && !IsToBeOmitted(variable, sourceBuilder, coBuilder);
 
-        return (eligible, eligibility.qualifiedName);
+        return (eligible, eligibility.eligibleType);
     }
 
     /// <summary>
@@ -323,10 +332,10 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForConstructor(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForConstructor(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         var eligibility = field.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
-        return ((field.AccessModifier == AccessModifier.Public && eligibility.isEligibe), eligibility.qualifiedName);
+        return ((field.AccessModifier == AccessModifier.Public && eligibility.isEligibe), eligibility.eligibleType);
     }
 
     /// <summary>
@@ -336,7 +345,7 @@ public static class SemanticsHelpers
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForConstructor(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForConstructor(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         return variable.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
     }
@@ -397,7 +406,7 @@ public static class SemanticsHelpers
 
 
 
-    public static (bool isEligibe, ITypeDeclaration? qualifiedName) IsMemberEligibleForConstructor(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForConstructor(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
     {
         return IsEligibleForTranspile(arrayTypeDeclaration, sourceBuilder);
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConfigurationConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConfigurationConstructorBuilder.cs
@@ -78,7 +78,8 @@ internal class CsOnlinerConfigurationConstructorBuilder : CsOnlinerConstructorBu
 
     public override void CreateVariableDeclaration(IVariableDeclaration semantics, IxNodeVisitor visitor)
     {
-        if (semantics.IsMemberEligibleForConstructor(SourceBuilder))
+        var eligibility = semantics.IsMemberEligibleForConstructor(SourceBuilder);
+        if (eligibility.isEligibe)
         {
             switch (semantics.Type)
             {
@@ -113,7 +114,8 @@ internal class CsOnlinerConfigurationConstructorBuilder : CsOnlinerConstructorBu
     private void AddArrayMemberInitialization(IArrayTypeDeclaration type, IVariableDeclaration field,
         IxNodeVisitor visitor)
     {
-        if (!type.IsMemberEligibleForConstructor(this.SourceBuilder))
+        var eligibility = type.IsMemberEligibleForConstructor(this.SourceBuilder);
+        if (!eligibility.isEligibe)
             return;
 
         AddToSource($"{field.Name}");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConfigurationConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConfigurationConstructorBuilder.cs
@@ -137,8 +137,9 @@ internal class CsOnlinerConfigurationConstructorBuilder : CsOnlinerConstructorBu
             case IStructuredTypeDeclaration structuredTypeDeclaration:
             case IEnumTypeDeclaration enumTypeDeclaration:
             case INamedValueTypeDeclaration namedValueTypeDeclaration:
-                AddToSource("new");
-                type.ElementTypeAccess.Type.Accept(visitor, this);
+                AddToSource("new");      
+                eligibility.eligibleType.Accept(visitor, this);
+                //type.ElementTypeAccess.Type.Accept(visitor, this);
                 break;
             case IScalarTypeDeclaration scalarTypeDeclaration:
                 AddToSource($"@Connector.ConnectorAdapter.AdapterFactory.Create{IecToAdapterExtensions.ToAdapterType(scalarTypeDeclaration)}");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs
@@ -69,7 +69,7 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
         var eligibility = fieldDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
         if (eligibility.isEligibe)
         {
-            switch (fieldDeclaration.Type)
+            switch (eligibility.eligibleType)
             {
                 case IArrayTypeDeclaration array:
                     AddArrayMemberInitialization(array, fieldDeclaration, visitor);
@@ -110,7 +110,7 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
         var elibility = semantics.IsMemberEligibleForConstructor(SourceBuilder);
         if (elibility.isEligibe)
         {
-            switch (semantics.Type)
+            switch (elibility.eligibleType)
             {
                 case IArrayTypeDeclaration array:
                     AddArrayMemberInitialization(array, semantics, visitor);
@@ -152,7 +152,9 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
 
     public void CreateArrayTypeDeclaration(IArrayTypeDeclaration arrayTypeDeclaration, IxNodeVisitor visitor)
     {
-        arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
+        var type = this.SourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess);
+        type.Accept(visitor, this);
+        //arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
         AddToSource("[");
         AddToSource(string.Join(",",
             arrayTypeDeclaration.Dimensions.Select(p => p.CountOfElements.ToString(CultureInfo.InvariantCulture))));
@@ -292,6 +294,7 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
 
         AddToSource($"{field.Name}");
         AddToSource("= new");
+        //eligibility.eligibleType.Accept(visitor, this);
         type.Accept(visitor, this);
         AddToSource(";");
 
@@ -302,7 +305,7 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
                     $"\"{field.Name}\", " +
                     "(p, rt, st) => ");
 
-        switch (type.ElementTypeAccess.Type)
+        switch (eligibility.eligibleType)
         {
             
             case IClassDeclaration classDeclaration:
@@ -310,7 +313,8 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
             case IEnumTypeDeclaration enumTypeDeclaration:
             case INamedValueTypeDeclaration namedValueTypeDeclaration:
                 AddToSource("new");
-                type.ElementTypeAccess.Type.Accept(visitor, this);
+                eligibility.eligibleType.Accept(visitor, this);
+                //type.ElementTypeAccess.Type.Accept(visitor, this);
                 break;
             case IScalarTypeDeclaration scalarTypeDeclaration:
                 AddToSource($"@Connector.ConnectorAdapter.AdapterFactory.Create{IecToAdapterExtensions.ToAdapterType(scalarTypeDeclaration)}");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs
@@ -66,7 +66,8 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
 
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+        var eligibility = fieldDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+        if (eligibility.isEligibe)
         {
             switch (fieldDeclaration.Type)
             {
@@ -106,8 +107,8 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
 
     public virtual void CreateVariableDeclaration(IVariableDeclaration semantics, IxNodeVisitor visitor)
     {
-
-        if (semantics.IsMemberEligibleForConstructor(SourceBuilder))
+        var elibility = semantics.IsMemberEligibleForConstructor(SourceBuilder);
+        if (elibility.isEligibe)
         {
             switch (semantics.Type)
             {
@@ -285,7 +286,8 @@ internal class CsOnlinerConstructorBuilder : ICombinedThreeVisitor
     private void AddArrayMemberInitialization(IArrayTypeDeclaration type, IStorageDeclaration field,
         IxNodeVisitor visitor)
     {
-        if(!type.IsMemberEligibleForConstructor(this.SourceBuilder))
+        var eligibility = type.IsMemberEligibleForConstructor(this.SourceBuilder);
+        if (!eligibility.isEligibe)
             return;
 
         AddToSource($"{field.Name}");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -49,7 +49,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder))
+        var eligible = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder);
+        if (eligible.isEligibe)
         {
             AddToSource(fieldDeclaration.Pragmas.AddAttributes());
 
@@ -72,7 +73,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    if (array.IsEligibleForTranspile(SourceBuilder))
+                    var eligibility = array.IsEligibleForTranspile(SourceBuilder);
+                    if (eligibility.isEligibe)
                     {
                         AddToSource($"{fieldDeclaration.AccessModifier.Transform()} ");
                         fieldDeclaration.Type.Accept(visitor, this);
@@ -138,7 +140,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateVariableDeclaration(IVariableDeclaration semantics, IxNodeVisitor visitor)
     {
-        if (semantics.IsMemberEligibleForTranspile(SourceBuilder))
+        var eligibility = semantics.IsMemberEligibleForTranspile(SourceBuilder);
+        if (eligibility.isEligibe)
         {
             AddToSource(semantics.Pragmas.AddAttributes());
 
@@ -161,7 +164,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    if (array.IsEligibleForTranspile(SourceBuilder))
+                    var arrayEligible = array.IsEligibleForTranspile(SourceBuilder);
+                    if (arrayEligible.isEligibe)
                     {
                         AddToSource($"public");
                         semantics.Type.Accept(visitor, this);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -32,7 +32,9 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateArrayTypeDeclaration(IArrayTypeDeclaration arrayTypeDeclaration, IxNodeVisitor visitor)
     {
-        arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
+        var type = this.SourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess);
+        //arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
+        type.Accept(visitor, this);
         AddToSource("[]");
     }
 
@@ -49,8 +51,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        var eligible = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder);
-        if (eligible.isEligibe)
+        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder);
+        if (eligibility.isEligibe)
         {
             AddToSource(fieldDeclaration.Pragmas.AddAttributes());
 
@@ -68,15 +70,17 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource(
                         $"[AXSharp.Connector.EnumeratorDiscriminatorAttribute(typeof({namedValue.GetQualifiedName()}))]");
                     AddToSource($"{fieldDeclaration.AccessModifier.Transform()} ");
-                    fieldDeclaration.Type.Accept(visitor, this);
+                    eligibility.eligibleType.Accept(visitor, this);
+                    //fieldDeclaration.Type.Accept(visitor, this);
                     AddToSource($" {fieldDeclaration.Name}");
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    var eligibility = array.IsEligibleForTranspile(SourceBuilder);
-                    if (eligibility.isEligibe)
+                    var arrayEligibility = array.IsEligibleForTranspile(SourceBuilder);
+                    if (arrayEligibility.isEligibe)
                     {
                         AddToSource($"{fieldDeclaration.AccessModifier.Transform()} ");
+                        //arrayEligibility.eligibleType.Accept(visitor, this);
                         fieldDeclaration.Type.Accept(visitor, this);
                         AddToSource($" {fieldDeclaration.Name}");
                         AddToSource("{get;}");
@@ -84,7 +88,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     break;
                 default:
                     AddToSource($"{fieldDeclaration.AccessModifier.Transform()} ");
-                    fieldDeclaration.Type.Accept(visitor, this);
+                    eligibility.eligibleType.Accept(visitor, this);
+                    //fieldDeclaration.Type.Accept(visitor, this);
                     AddToSource($" {fieldDeclaration.Name}");
                     AddToSource("{get;}");
                     break;
@@ -146,7 +151,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
             AddToSource(semantics.Pragmas.AddAttributes());
 
             // TODO: This is not nice refactor, also we should embed the int wrapper into actual member of enum type!
-            switch (semantics.Type)
+            switch (eligibility.eligibleType)
             {
                 case IEnumTypeDeclaration @enum:
                     AddToSource($"[AXSharp.Connector.EnumeratorDiscriminatorAttribute(typeof({@enum.GetQualifiedName()}))]");
@@ -159,7 +164,8 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource(
                         $"[AXSharp.Connector.EnumeratorDiscriminatorAttribute(typeof({namedValue.GetQualifiedName()}))]");
                     AddToSource($"public");
-                    semantics.Type.Accept(visitor, this);
+                    eligibility.eligibleType.Accept(visitor, this);
+                    //semantics.Type.Accept(visitor, this);
                     AddToSource($" {semantics.Name}");
                     AddToSource("{get;}");
                     break;
@@ -168,14 +174,16 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     if (arrayEligible.isEligibe)
                     {
                         AddToSource($"public");
-                        semantics.Type.Accept(visitor, this);
+                        eligibility.eligibleType.Accept(visitor, this);
+                        //semantics.Type.Accept(visitor, this);
                         AddToSource($" {semantics.Name}");
                         AddToSource("{get;}");
                     }
                     break;
                 default:
                     AddToSource($"public");
-                    semantics.Type.Accept(visitor, this);
+                    eligibility.eligibleType.Accept(visitor, this);
+                    //semantics.Type.Accept(visitor, this);
                     AddToSource($" {semantics.Name}");
                     AddToSource("{get;}");
                     break;

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -52,7 +52,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
         var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder);
-        if (eligibility.isEligibe)
+        if (eligibility.isEligible)
         {
             AddToSource(fieldDeclaration.Pragmas.AddAttributes());
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
@@ -37,7 +37,7 @@ internal class CsOnlinerPlainerOnlineToPlainBuilder : ICombinedThreeVisitor
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
         var eligible = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
-        if (eligible.isEligibe)
+        if (eligible.isEligible)
         {
             CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
         }

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
@@ -36,7 +36,8 @@ internal class CsOnlinerPlainerOnlineToPlainBuilder : ICombinedThreeVisitor
     
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+        var eligible = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+        if (eligible.isEligibe)
         {
             CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
         }
@@ -49,7 +50,8 @@ internal class CsOnlinerPlainerOnlineToPlainBuilder : ICombinedThreeVisitor
 
     public void CreateVariableDeclaration(IVariableDeclaration variableDeclaration, IxNodeVisitor visitor)
     {
-        if (variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+        var eligibility = variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+        if (eligibility.isEligibe)
         {
             CreateAssignment(variableDeclaration.Type, variableDeclaration);
         }
@@ -70,7 +72,8 @@ internal class CsOnlinerPlainerOnlineToPlainBuilder : ICombinedThreeVisitor
                 AddToSource($"#pragma warning restore CS0612\n");
                 break;
             case IArrayTypeDeclaration arrayTypeDeclaration:
-                if (arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+                var arrayEligibility = arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+                if (arrayEligibility.isEligibe)
                 {
                     switch (arrayTypeDeclaration.ElementTypeAccess.Type)
                     {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
@@ -37,7 +37,7 @@ internal class CsOnlinerPlainerPlainToOnlineBuilder : ICombinedThreeVisitor
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
         var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
-        if (eligibility.isEligibe)
+        if (eligibility.isEligible)
         {
             CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
         }

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
@@ -36,7 +36,8 @@ internal class CsOnlinerPlainerPlainToOnlineBuilder : ICombinedThreeVisitor
     
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+        if (eligibility.isEligibe)
         {
             CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
         }
@@ -49,7 +50,8 @@ internal class CsOnlinerPlainerPlainToOnlineBuilder : ICombinedThreeVisitor
 
     public void CreateVariableDeclaration(IVariableDeclaration variableDeclaration, IxNodeVisitor visitor)
     {
-        if (variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+        var eligibility = variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+        if (eligibility.isEligibe)
         {
             CreateAssignment(variableDeclaration.Type, variableDeclaration);
         }
@@ -69,8 +71,8 @@ internal class CsOnlinerPlainerPlainToOnlineBuilder : ICombinedThreeVisitor
                 AddToSource($"#pragma warning restore CS0612\n");
                 break;
             case IArrayTypeDeclaration arrayTypeDeclaration:
-
-                if (arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+                var arrayEligibility = arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+                if (arrayEligibility.isEligibe)
                 {
                     switch (arrayTypeDeclaration.ElementTypeAccess.Type)
                     {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
@@ -36,7 +36,7 @@ namespace AXSharp.Compiler.Cs.Onliner
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
             var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
-            if (eligibility.isEligibe)
+            if (eligibility.isEligible)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
             }

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
@@ -35,7 +35,8 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
-            if (fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder,"POCO"))
+            var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            if (eligibility.isEligibe)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
             }
@@ -48,7 +49,8 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateVariableDeclaration(IVariableDeclaration variableDeclaration, IxNodeVisitor visitor)
         {
-            if (variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+            var eligibility = variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            if (eligibility.isEligibe)
             {
                 CreateAssignment(variableDeclaration.Type, variableDeclaration);
             }
@@ -66,8 +68,8 @@ namespace AXSharp.Compiler.Cs.Onliner
                     AddToSource($" await this.{declaration.Name}.{MethodName}Async(plain.{declaration.Name});");
                     break;
                 case IArrayTypeDeclaration arrayTypeDeclaration:
-
-                    if (arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+                    var arrayEligibility = arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+                    if (arrayEligibility.isEligibe)
                     {
                         switch (arrayTypeDeclaration.ElementTypeAccess.Type)
                         {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
@@ -36,7 +36,7 @@ namespace AXSharp.Compiler.Cs.Onliner
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
             var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
-            if (eligibility.isEligibe)
+            if (eligibility.isEligible)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
             }

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
@@ -35,7 +35,8 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
-            if (fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+            var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            if (eligibility.isEligibe)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
             }
@@ -48,7 +49,8 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateVariableDeclaration(IVariableDeclaration variableDeclaration, IxNodeVisitor visitor)
         {
-            if (variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+            var eligibility = variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            if (eligibility.isEligibe)
             {
                 CreateAssignment(variableDeclaration.Type, variableDeclaration);
             }
@@ -66,7 +68,8 @@ namespace AXSharp.Compiler.Cs.Onliner
                     AddToSource($" plain.{declaration.Name} = await {declaration.Name}.{MethodName}Async();");
                     break;
                 case IArrayTypeDeclaration arrayTypeDeclaration:
-                    if (arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+                    var arrayEligibility = arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+                    if (arrayEligibility.isEligibe)
                     {
                         switch (arrayTypeDeclaration.ElementTypeAccess.Type)
                         {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
@@ -155,12 +155,15 @@ public class CsOnlinerSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
         AddToSource($"{classDeclaration.AccessModifier.Transform()}partial class {classDeclaration.Name}{generic?.Product}");
         AddToSource(":");
 
+        
         var isExtended = false;
-        var extendedType = classDeclaration.ExtendedTypeAccesses.FirstOrDefault();
-        if (Compilation.GetSemanticTree().Types
-            .Any(p => p.FullyQualifiedName == extendedType?.Type.FullyQualifiedName))
+        AX.ST.Semantic.Model.ISemanticTypeAccess? extendedType = classDeclaration.ExtendedTypeAccesses.FirstOrDefault();
+
+        //TODO: Workaround for not fully qualified declarations. To be addressed with proper dependency handling in stc.
+        var extend = Compilation.FindTypeDeclaration(extendedType);
+        if (extend != null)
         {
-            AddToSource($"{extendedType.Type.FullyQualifiedName}{ReplaceGenericSignature(classDeclaration)}");
+            AddToSource($"{extend.FullyQualifiedName}{ReplaceGenericSignature(classDeclaration)}");
             isExtended = true;
         }
         else

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/HasChangedBuilder/CsOnlinerHasChangedBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/HasChangedBuilder/CsOnlinerHasChangedBuilder.cs
@@ -36,7 +36,7 @@ namespace AXSharp.Compiler.Cs.Onliner
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
             var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
-            if (eligibility.isEligibe)
+            if (eligibility.isEligible)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
             }

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/HasChangedBuilder/CsOnlinerHasChangedBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/HasChangedBuilder/CsOnlinerHasChangedBuilder.cs
@@ -35,7 +35,8 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
-            if (fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+            var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            if (eligibility.isEligibe)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);
             }
@@ -48,7 +49,8 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateVariableDeclaration(IVariableDeclaration variableDeclaration, IxNodeVisitor visitor)
         {
-            if (variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO"))
+            var eligibility = variableDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            if (eligibility.isEligibe)
             {
                 CreateAssignment(variableDeclaration.Type, variableDeclaration);
             }
@@ -67,7 +69,8 @@ namespace AXSharp.Compiler.Cs.Onliner
                     AddToSource($" if(await {declaration.Name}.{MethodName}(plain.{declaration.Name}, latest.{declaration.Name})) somethingChanged = true;");
                     break;
                 case IArrayTypeDeclaration arrayTypeDeclaration:
-                    if (arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+                    var eligibility = arrayTypeDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+                    if (eligibility.isEligibe)
                     {
                         switch (arrayTypeDeclaration.ElementTypeAccess.Type)
                         {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainConstructorBuilder.cs
@@ -66,7 +66,8 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
 
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForConstructor(SourceBuilder))
+        var eligibility = fieldDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
+        if (eligibility.isEligibe)
         {
             switch (fieldDeclaration.Type)
             {
@@ -149,7 +150,8 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
     private void AddArrayMemberInitialization(IArrayTypeDeclaration type, IFieldDeclaration field,
         IxNodeVisitor visitor)
     {
-        if(!type.IsMemberEligibleForConstructor(this.SourceBuilder))
+        var eligibility = type.IsMemberEligibleForConstructor(this.SourceBuilder);
+        if (!eligibility.isEligibe)
             return;
         
         switch (type.ElementTypeAccess.Type)
@@ -161,7 +163,7 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
                 AddToSource("#pragma warning disable CS0612\n");
                 AddToSource($"{typeof(Arrays).n()}.InstantiateArray({field.Name}, " +
                             "() => ");
-                AddToSource("new");
+                AddToSource("new");                
                 type.ElementTypeAccess.Type.Accept(visitor, this);
                 var dimensions = "new[] {";
                 foreach (var dimension in type.Dimensions)

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainConstructorBuilder.cs
@@ -72,7 +72,7 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
             switch (fieldDeclaration.Type)
             {
                 case IArrayTypeDeclaration array:
-                    AddArrayMemberInitialization(array, fieldDeclaration, visitor);
+                    AddArrayMemberInitialization(array, fieldDeclaration, visitor);                    
                     break;
             }
         }
@@ -149,12 +149,12 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
 
     private void AddArrayMemberInitialization(IArrayTypeDeclaration type, IFieldDeclaration field,
         IxNodeVisitor visitor)
-    {
+    {       
         var eligibility = type.IsMemberEligibleForConstructor(this.SourceBuilder);
         if (!eligibility.isEligibe)
             return;
         
-        switch (type.ElementTypeAccess.Type)
+        switch (eligibility.eligibleType)
         {
             case IClassDeclaration classDeclaration:
             case IStructuredTypeDeclaration structuredTypeDeclaration:
@@ -163,8 +163,9 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
                 AddToSource("#pragma warning disable CS0612\n");
                 AddToSource($"{typeof(Arrays).n()}.InstantiateArray({field.Name}, " +
                             "() => ");
-                AddToSource("new");                
-                type.ElementTypeAccess.Type.Accept(visitor, this);
+                AddToSource("new");
+                eligibility.eligibleType.Accept(visitor, this);
+                //type.ElementTypeAccess.Type.Accept(visitor, this);
                 var dimensions = "new[] {";
                 foreach (var dimension in type.Dimensions)
                 {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
@@ -112,13 +112,15 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
     /// <inheritdoc />
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForTranspile(this))
+        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(this);
+        if (eligibility.isEligibe)
         {           
             AddToSource(fieldDeclaration.Pragmas.AddedPropertiesAsAttributes());
             switch (fieldDeclaration.Type)
             {
                 case IArrayTypeDeclaration arrayType:
-                    if (arrayType.IsEligibleForTranspile(this))
+                    var arrayEligibility = arrayType.IsEligibleForTranspile(this);
+                    if (arrayEligibility.isEligibe)
                     {
                         fieldDeclaration.Pragmas.AddAttributes();
                         AddToSource($"{fieldDeclaration.AccessModifier.Transform()}");
@@ -274,13 +276,15 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
     /// <inheritdoc />
     public void CreateVariableDeclaration(IVariableDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        if (fieldDeclaration.IsMemberEligibleForTranspile(this))
+        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(this);
+        if (eligibility.isEligibe)
         {            
             AddToSource(fieldDeclaration.Pragmas.AddedPropertiesAsAttributes());
             switch (fieldDeclaration.Type)
             {
                 case IArrayTypeDeclaration arrayType:
-                    if (arrayType.IsEligibleForTranspile(this))
+                    var arrayEligibility = arrayType.IsEligibleForTranspile(this);
+                    if (arrayEligibility.isEligibe)
                     {
                         fieldDeclaration.Pragmas.AddAttributes();
                         AddToSource($"public");
@@ -369,7 +373,9 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
     /// <inheritdoc />
     public void CreateArrayTypeDeclaration(IArrayTypeDeclaration arrayTypeDeclaration, IxNodeVisitor visitor)
     {
-        if (arrayTypeDeclaration.IsEligibleForTranspile(this)) return;
+        // WATCH!
+        var eligibility = arrayTypeDeclaration.IsEligibleForTranspile(this);
+        if (!eligibility.isEligibe) return;
 
         arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
         AddToSource("[]");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
@@ -116,7 +116,7 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
         var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(this);
-        if (eligibility.isEligibe)
+        if (eligibility.isEligible)
         {           
             AddToSource(fieldDeclaration.Pragmas.AddedPropertiesAsAttributes());
             switch (fieldDeclaration.Type)

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
@@ -74,14 +74,17 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
         AddToSource(classDeclaration.Pragmas.AddedPropertiesAsAttributes());
         
         AddToSource($"{classDeclaration.AccessModifier.Transform()}partial class {classDeclaration.Name}");
+       
+        var isExtended = false;
+        AX.ST.Semantic.Model.ISemanticTypeAccess? extendedType = classDeclaration.ExtendedTypeAccesses.FirstOrDefault();
 
-        var isExtended = Compilation.GetSemanticTree().Types
-            .Any(p => p.FullyQualifiedName == classDeclaration.ExtendedTypeAccesses.FirstOrDefault()?.Type.FullyQualifiedName);
-
-        if (isExtended)
-            AddToSource($" : {classDeclaration.ExtendedTypeAccesses.FirstOrDefault()?.Type.FullyQualifiedName}");
-
-
+        //TODO: Workaround for not fully qualified declarations. To be addressed with proper dependency handling in stc.
+        var extend = Compilation.FindTypeDeclaration(extendedType);
+        if (extend != null)
+        {
+            AddToSource($" : {extend.FullyQualifiedName}");
+            isExtended = true;
+        }
 
         AddToSource(isExtended ? ", AXSharp.Connector.IPlain" : ": AXSharp.Connector.IPlain");
 
@@ -124,13 +127,15 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
                     {
                         fieldDeclaration.Pragmas.AddAttributes();
                         AddToSource($"{fieldDeclaration.AccessModifier.Transform()}");
-                        arrayType.ElementTypeAccess.Type.Accept(visitor, this);
+                        arrayEligibility.eligibleType.Accept(visitor, this);
+                        //arrayType.ElementTypeAccess.Type.Accept(visitor, this);
                         AddToSource("[]");
                         AddToSource($" {fieldDeclaration.Name}");
                         AddToSource("{get; set;}");
 
                         AddToSource($"= new");
-                        arrayType.ElementTypeAccess.Type.Accept(visitor, this);
+                        arrayEligibility.eligibleType.Accept(visitor, this);
+                        //arrayType.ElementTypeAccess.Type.Accept(visitor, this);
                         AddToSource($"[");
                         AddToSource(string.Join(",", arrayType.Dimensions.Select(p => p.CountOfElements)));
                         AddToSource($"];");
@@ -151,7 +156,8 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
                 case IStructuredTypeDeclaration s:
                     AddPropertyDeclaration(fieldDeclaration, visitor);
                     AddToSource(" = new ");
-                    fieldDeclaration.Type.Accept(visitor, this);
+                    eligibility.eligibleType.Accept(visitor, this);
+                    //fieldDeclaration.Type.Accept(visitor, this);
                     AddToSource("();");
                     break;
             }
@@ -288,13 +294,15 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
                     {
                         fieldDeclaration.Pragmas.AddAttributes();
                         AddToSource($"public");
-                        arrayType.ElementTypeAccess.Type.Accept(visitor, this);
+                        arrayEligibility.eligibleType.Accept(visitor, this);
+                        //arrayType.ElementTypeAccess.Type.Accept(visitor, this);
                         AddToSource("[]");
                         AddToSource($" {fieldDeclaration.Name}");
                         AddToSource("{get; set;}");
 
                         AddToSource($"= new");
-                        arrayType.ElementTypeAccess.Type.Accept(visitor, this);
+                        arrayEligibility.eligibleType.Accept(visitor, this);
+                        //arrayType.ElementTypeAccess.Type.Accept(visitor, this);
                         AddToSource($"[");
                         AddToSource(string.Join(",", arrayType.Dimensions.Select(p => p.CountOfElements)));
                         AddToSource($"];");
@@ -315,7 +323,8 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
                 case IStructuredTypeDeclaration s:
                     AddPropertyDeclaration(fieldDeclaration, visitor);                    
                     AddToSource(" = new ");
-                    fieldDeclaration.Type.Accept(visitor, this);
+                    eligibility.eligibleType.Accept(visitor, this);
+                    //fieldDeclaration.Type.Accept(visitor, this);
                     AddToSource("();");
                     break;
             }
@@ -377,7 +386,8 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
         var eligibility = arrayTypeDeclaration.IsEligibleForTranspile(this);
         if (!eligibility.isEligibe) return;
 
-        arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
+        eligibility.eligibleType.Accept(visitor, this);
+        //arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
         AddToSource("[]");
     }
 

--- a/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
+++ b/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     },
     "ixc-simple-template": {
       "commandName": "Project",
-      "workingDirectory": "c:\\W\\Develop\\gh\\inxton\\_axopen\\axopen.templates\\axopen.template.simple\\ax"
+      "workingDirectory": "C:\\W\\Develop\\gh\\inxton\\simatic-ax\\axopen.templates\\axopen.template.simple\\ax"
     },
     "ixc-template-ref": {
       "commandName": "Project",

--- a/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
+++ b/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
@@ -10,6 +10,7 @@
     },
     "ixc-simple-template": {
       "commandName": "Project",
+      "commandLineArgs": "--skip-deps",
       "workingDirectory": "C:\\W\\Develop\\gh\\inxton\\simatic-ax\\axopen.templates\\axopen.template.simple\\ax"
     },
     "ixc-template-ref": {


### PR DESCRIPTION
This pull request includes several changes to the `AXSharp.Cs.Compiler` project to enhance type handling and eligibility checks for transpilation. The most significant changes include updating method signatures to return tuples, adding new methods for determining fully qualified names, and modifying eligibility checks to use these new methods.

Enhancements to type handling and eligibility checks:

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs`](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L29-R189): Updated multiple methods (`IsMemberEligibleForTranspile`, `IsEligibleForTranspile`, `IsMemberEligibleForConstructor`) to return tuples containing eligibility status and type declaration. Added methods to find type declarations and determine fully qualified names. [[1]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L29-R189) [[2]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L81-R238) [[3]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L109-R266) [[4]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L138-R295) [[5]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L165-R325) [[6]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L179-R338) [[7]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L191-R348) [[8]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L252-R409)

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConfigurationConstructorBuilder.cs`](diffhunk://#diff-a684f46fcbfe25be1deaaa05af2f18b48c1106f4bcb191e5c20ce9cc21d55ee7L81-R82): Updated `CreateVariableDeclaration` and `AddArrayMemberInitialization` methods to use the new eligibility check tuple format. [[1]](diffhunk://#diff-a684f46fcbfe25be1deaaa05af2f18b48c1106f4bcb191e5c20ce9cc21d55ee7L81-R82) [[2]](diffhunk://#diff-a684f46fcbfe25be1deaaa05af2f18b48c1106f4bcb191e5c20ce9cc21d55ee7L116-R118) [[3]](diffhunk://#diff-a684f46fcbfe25be1deaaa05af2f18b48c1106f4bcb191e5c20ce9cc21d55ee7L139-R142)

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerConstructorBuilder.cs`](diffhunk://#diff-cdaf03763579ae13e98dc36d965fe2248bebaad4e6d967d227d40fa4315aa65cL69-R72): Modified `CreateFieldDeclaration` and `CreateVariableDeclaration` methods to switch on the eligible type returned by the new eligibility check methods. [[1]](diffhunk://#diff-cdaf03763579ae13e98dc36d965fe2248bebaad4e6d967d227d40fa4315aa65cL69-R72) [[2]](diffhunk://#diff-cdaf03763579ae13e98dc36d965fe2248bebaad4e6d967d227d40fa4315aa65cL109-R113)

Version update:

* [`GitVersion.yml`](diffhunk://#diff-1b800222c322c27580a65856212fc4fd9bf1128603cb0864b2e85f6f22b567c9L2-R2): Updated `next-version` from `0.23.0` to `0.24.0` to reflect the new changes.