### PR TITLE
Update stc to v9

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Compiler/Core/IxNodeVisitor.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/Core/IxNodeVisitor.cs
@@ -122,6 +122,11 @@ public partial class IxNodeVisitor : ISemanticNodeVisitor<ICombinedThreeVisitor>
         throw new NotSupportedException();
     }
 
+    public void Visit(IClassMethodDeclaration methodDeclaration, ICombinedThreeVisitor data)
+    {
+        throw new NotSupportedException();
+    }
+
     void ISemanticNodeVisitor<ICombinedThreeVisitor>.Visit(IMethodPrototypeDeclaration methodPrototypeDeclaration,
         ICombinedThreeVisitor data)
     {

--- a/src/AXSharp.compiler/src/ixd/Mapper/CodeToYamlMapper.cs
+++ b/src/AXSharp.compiler/src/ixd/Mapper/CodeToYamlMapper.cs
@@ -117,7 +117,7 @@ namespace AXSharp.ixc_doc.Mapper
             var item = PopulateItem((IDeclaration)methodDeclaration);
             item.Uid = Helpers.Helpers.GetBaseUid(methodDeclaration);
             item.Id = Helpers.Helpers.GetBaseUid(methodDeclaration);
-            item.Parent = methodDeclaration.ContainingClass.FullyQualifiedName;
+            item.Parent = methodDeclaration.ContainingStructuredType.FullyQualifiedName;
             item.Type = "Method";
             item.Syntax = new Syntax
             {

--- a/src/AXSharp.compiler/src/ixd/Visitors/MyNodeVisitor.cs
+++ b/src/AXSharp.compiler/src/ixd/Visitors/MyNodeVisitor.cs
@@ -112,6 +112,11 @@ namespace AXSharp.ixc_doc.Visitors
             data.CreateMethodYaml(methodDeclaration, this);
         }
 
+        public void Visit(IClassMethodDeclaration methodDeclaration, IYamlBuiderVisitor data)
+        {
+            data.CreateMethodYaml(methodDeclaration, this);
+        }
+
         public void Visit(IMethodPrototypeDeclaration methodPrototypeDeclaration, IYamlBuiderVisitor data)
         {
             data.CreateMethodPrototypeYaml(methodPrototypeDeclaration, this);

--- a/src/apax/apax-lock.json
+++ b/src/apax/apax-lock.json
@@ -7,25 +7,25 @@
     "name": "s",
     "version": "0.0.0",
     "devDependencies": {
-      "@ax/stc": "8.0.17"
+      "@ax/stc": "9.1.36"
     }
   },
   "packages": {
     "@ax/stc": {
       "name": "@ax/stc",
-      "version": "8.0.17",
-      "integrity": "sha512-Ym2uWEmfrkhm2Z/ODujUwQOiAwQ2p0fv9hLTJGL+zwYMjAwja71JayMLSOO+cX0gv8VexrxISDa66jouT+XySA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc/-/stc-8.0.17.tgz",
+      "version": "9.1.36",
+      "integrity": "sha512-v1crfIUg8rUVmrhtSTDoZZNub9At2iMiDgR4BK+3SA1VmhO7swGwnff0OkSoteE60kdxN+70AmKJJWlX+11WTA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc/-/stc-9.1.36.tgz",
       "dependencies": {
-        "@ax/stc-win-x64": "8.0.17",
-        "@ax/stc-linux-x64": "8.0.17"
+        "@ax/stc-win-x64": "9.1.36",
+        "@ax/stc-linux-x64": "9.1.36"
       }
     },
     "@ax/stc-win-x64": {
       "name": "@ax/stc-win-x64",
-      "version": "8.0.17",
-      "integrity": "sha512-vOnWIY+dLfASN2s7exuy7pQU/KKTp9ej3uMn86vLTXtjF5YUECInNYOM9kY6hQdnJFJH6RirxzbiRJftjvLHuw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-win-x64/-/stc-win-x64-8.0.17.tgz",
+      "version": "9.1.36",
+      "integrity": "sha512-Ibmdf+eqfe4GzSxeZz3bxW3NStfscNDVtlmjI2enjpmSIybTak3xH4JHpQHJFkJEJqx9aMndue3GFKpPs16ovw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-win-x64/-/stc-win-x64-9.1.36.tgz",
       "os": [
         "win32"
       ],
@@ -33,14 +33,14 @@
         "x64"
       ],
       "dependencies": {
-        "@ax/st-docs": "8.0.17"
+        "@ax/st-docs": "9.1.36"
       }
     },
     "@ax/stc-linux-x64": {
       "name": "@ax/stc-linux-x64",
-      "version": "8.0.17",
-      "integrity": "sha512-BnpkLdkExZ6n6wyKHprrCPfQOu4FK6FTTt8ieVbrjOwABSJxez3ls9GBEpUOJKxqJa05epbR2nIHYoOO1pFKtQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-linux-x64/-/stc-linux-x64-8.0.17.tgz",
+      "version": "9.1.36",
+      "integrity": "sha512-mlOpXtZ1V2VZNFRSb8PyqhQpPZ0a2Q3m0J/d0n/s4iIIEaneUON/JtywCTAQdvQJYer5PuKDoZf/dBLlgNRuRQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-linux-x64/-/stc-linux-x64-9.1.36.tgz",
       "os": [
         "linux"
       ],
@@ -48,14 +48,14 @@
         "x64"
       ],
       "dependencies": {
-        "@ax/st-docs": "8.0.17"
+        "@ax/st-docs": "9.1.36"
       }
     },
     "@ax/st-docs": {
       "name": "@ax/st-docs",
-      "version": "8.0.17",
-      "integrity": "sha512-bvMaT+GcSwF9ahzqI+wHBlCDfASqnJTDHwuBgVuR68u3R9cLaoOLnosw4HBoJRlBxWyooKB9bn+u++jRaekRNg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-docs/-/st-docs-8.0.17.tgz",
+      "version": "9.1.36",
+      "integrity": "sha512-xxUUXzm9VSf7p0yaOKZ+kep2+JDq9eqD2ddGNhysvocLI3SZhDxF693axQpCoJA2PxhpJdut+lXSZkCgNOVIsA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-docs/-/st-docs-9.1.36.tgz",
       "dependencies": {}
     }
   },

--- a/src/apax/apax.yml
+++ b/src/apax/apax.yml
@@ -5,6 +5,6 @@ targets:
   - "1500"
   - axunit-llvm
 devDependencies:
-  "@ax/stc": 8.0.17
+  "@ax/stc": 9.1.36
 installStrategy: strict
 apaxVersion: 3.1.1

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/geolocation.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/geolocation.g.cs
@@ -4,30 +4,30 @@ using AXSharp.Connector;
 
 namespace Pocos
 {
-    [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Location")]
+    [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Location")]
     public partial class GeoLocation : AXSharp.Connector.IPlain
     {
         public GeoLocation()
         {
         }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Latitude [°]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Latitude [°]")]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeMinimum", -90.0f)]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeMaximum", 90.0f)]
         public Single Latitude { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Logitude [°]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Logitude [°]")]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeMinimum", 0.0f)]
         [AXSharp.Connector.AddedPropertiesAttribute("AttributeMaximum", 180.0f)]
         public Single Longitude { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Altitude [m]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Altitude [m]")]
         public Single Altitude { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Short descriptor")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Short descriptor")]
         public string Description { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Long descriptor")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Long descriptor")]
         public string LongDescription { get; set; } = string.Empty;
     }
 }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/ixcomponent.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/ixcomponent.g.cs
@@ -10,13 +10,13 @@ namespace Pocos
         {
         }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My integer")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My integer")]
         public Int16 my_int { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My string")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My string")]
         public string my_string { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My bool")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My bool")]
         public Boolean my_bool { get; set; }
     }
 
@@ -28,13 +28,13 @@ namespace Pocos
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My integer")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My integer")]
             public Int16 my_int { get; set; }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My string")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My string")]
             public string my_string { get; set; } = string.Empty;
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My bool")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My bool")]
             public Boolean my_bool { get; set; }
         }
     }
@@ -47,13 +47,13 @@ namespace Pocos
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My integer")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My integer")]
             public Int16 my_int { get; set; }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My string")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My string")]
             public string my_string { get; set; } = string.Empty;
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "My bool")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"My bool")]
             public Boolean my_bool { get; set; }
         }
     }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/measurement.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/measurement.g.cs
@@ -12,16 +12,16 @@ namespace Pocos
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Minimum")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Minimum")]
             public Single Min { get; set; }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Measured")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Measured")]
             public Single Acquired { get; set; }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Maximum")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Maximum")]
             public Single Max { get; set; }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Measurement Result")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Measurement Result")]
             public Int16 Result { get; set; }
         }
 
@@ -31,16 +31,16 @@ namespace Pocos
             {
             }
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Stack panel")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Stack panel")]
             public MeasurementExample.Measurement measurement_stack { get; set; } = new MeasurementExample.Measurement();
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Wrap panel")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Wrap panel")]
             public MeasurementExample.Measurement measurement_wrap { get; set; } = new MeasurementExample.Measurement();
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Grid")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Grid")]
             public MeasurementExample.Measurement measurement_grid { get; set; } = new MeasurementExample.Measurement();
 
-            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "Tabs")]
+            [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"Tabs")]
             public MeasurementExample.Measurement measurement_tabs { get; set; } = new MeasurementExample.Measurement();
         }
     }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/test/border.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/test/border.g.cs
@@ -10,40 +10,40 @@ namespace Pocos
         {
         }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#Integer From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#Integer From PLC#>")]
         public Int16 testInteger { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#UInteger From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#UInteger From PLC#>")]
         public Int16 testUInteger { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#STRING From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#STRING From PLC#>")]
         public string testString { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#WORD From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#WORD From PLC#>")]
         public UInt16 testWord { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#BYTE From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#BYTE From PLC#>")]
         public Byte testByte { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#REAL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#REAL From PLC#>")]
         public Single testReal { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#LREAL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#LREAL From PLC#>")]
         public Double testLReal { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#BOOL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#BOOL From PLC#>")]
         public Boolean testBool { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#DATE From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#DATE From PLC#>")]
         public DateOnly TestDate { get; set; } = new DateOnly(1970, 1, 1);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#DATE_AND_TIME From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#DATE_AND_TIME From PLC#>")]
         public DateTime TestDateTime { get; set; } = new DateTime(1970, 1, 1);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#TIME_OF_DAY From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#TIME_OF_DAY From PLC#>")]
         public TimeSpan TestTimeOfDay { get; set; } = default(TimeSpan);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#ENUM Station status#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#ENUM Station status#>")]
         public global::enumStationStatus Status { get; set; }
     }
 }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/test/groupbox.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/test/groupbox.g.cs
@@ -10,40 +10,40 @@ namespace Pocos
         {
         }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#Integer From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#Integer From PLC#>")]
         public Int16 testInteger { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#UInteger From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#UInteger From PLC#>")]
         public Int16 testUInteger { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#STRING From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#STRING From PLC#>")]
         public string testString { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#WORD From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#WORD From PLC#>")]
         public UInt16 testWord { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#BYTE From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#BYTE From PLC#>")]
         public Byte testByte { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#REAL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#REAL From PLC#>")]
         public Single testReal { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#LREAL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#LREAL From PLC#>")]
         public Double testLReal { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#BOOL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#BOOL From PLC#>")]
         public Boolean testBool { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#DATE From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#DATE From PLC#>")]
         public DateOnly TestDate { get; set; } = new DateOnly(1970, 1, 1);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#DATE_AND_TIME From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#DATE_AND_TIME From PLC#>")]
         public DateTime TestDateTime { get; set; } = new DateTime(1970, 1, 1);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#TIME_OF_DAY From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#TIME_OF_DAY From PLC#>")]
         public TimeSpan TestTimeOfDay { get; set; } = default(TimeSpan);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#ENUM Station status#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#ENUM Station status#>")]
         public global::enumStationStatus Status { get; set; }
     }
 }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/test/test_primitive.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/test/test_primitive.g.cs
@@ -10,40 +10,40 @@ namespace Pocos
         {
         }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#Integer From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#Integer From PLC#>")]
         public Int16 testInteger { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#UInteger From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#UInteger From PLC#>")]
         public Int16 testUInteger { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#STRING From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#STRING From PLC#>")]
         public string testString { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#WORD From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#WORD From PLC#>")]
         public UInt16 testWord { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#BYTE From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#BYTE From PLC#>")]
         public Byte testByte { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#REAL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#REAL From PLC#>")]
         public Single testReal { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#LREAL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#LREAL From PLC#>")]
         public Double testLReal { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#BOOL From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#BOOL From PLC#>")]
         public Boolean testBool { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#DATE From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#DATE From PLC#>")]
         public DateOnly TestDate { get; set; } = new DateOnly(1970, 1, 1);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#DATE_AND_TIME From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#DATE_AND_TIME From PLC#>")]
         public DateTime TestDateTime { get; set; } = new DateTime(1970, 1, 1);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#TIME_OF_DAY From PLC#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#TIME_OF_DAY From PLC#>")]
         public TimeSpan TestTimeOfDay { get; set; } = default(TimeSpan);
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "<#ENUM Station status#>")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"<#ENUM Station status#>")]
         public global::enumStationStatus Status { get; set; }
     }
 }

--- a/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/weatherBase.g.cs
+++ b/src/sanbox/integration/ix-integration-plc/ix/.g/POCO/weatherBase.g.cs
@@ -16,22 +16,22 @@ namespace Pocos
         public string Description { get; set; } = string.Empty;
         public string LongDescription { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "this has [ReadOnce()] attribute will be readon only once...")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"this has [ReadOnce()] attribute will be readon only once...")]
         public Int16 StartCounter { get; set; }
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore()] must not be displayed!")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"[RenderIgnore()] must not be displayed!")]
         public string RenderIgnoreAllToghether { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Control'')]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"[RenderIgnore(''Control'')]")]
         public string RenderIgnoreWhenControl { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Display'')]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"[RenderIgnore(''Display'')]")]
         public string RenderIgnoreWhenDisplay { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Control'', ''ShadowControl'')]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"[RenderIgnore(''Control'', ''ShadowControl'')]")]
         public string RenderIgnoreWhenControlAndShadow { get; set; } = string.Empty;
 
-        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", "[RenderIgnore(''Display'', ''ShadowDisplay'')]")]
+        [AXSharp.Connector.AddedPropertiesAttribute("AttributeName", @"[RenderIgnore(''Display'', ''ShadowDisplay'')]")]
         public string RenderIgnoreWhenDisplayAndShadow { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
This pull request includes several changes across multiple files to update method declarations, modify YAML mappings, upgrade dependencies, and adjust attribute annotations. The most important changes include adding support for `IClassMethodDeclaration`, updating a parent reference in method declarations, and upgrading the `@ax/stc` package version.

### Method Declaration Updates:
* [`src/AXSharp.compiler/src/AXSharp.Compiler/Core/IxNodeVisitor.cs`](diffhunk://#diff-ec13f2400d93f7ca7d76c03f8f824f2188f0b5186c81eb864e803bd3429fc4e4R125-R129): Added support for `IClassMethodDeclaration` in `Visit` method.
* [`src/AXSharp.compiler/src/ixd/Visitors/MyNodeVisitor.cs`](diffhunk://#diff-a87145d3ab365c93f965b996c185260b83400fc2fb0d65392bfdec0cc4a4a40dR115-R119): Added support for `IClassMethodDeclaration` in `Visit` method.

### YAML Mapping Modifications:
* [`src/AXSharp.compiler/src/ixd/Mapper/CodeToYamlMapper.cs`](diffhunk://#diff-f98861c9f2c37d9bfd85803d3b12317ee556c43ac4003f3c1b102fe3dc0a7759L120-R120): Updated `Parent` property to use `ContainingStructuredType` instead of `ContainingClass` in `PopulateItem` method.

### Dependency Upgrades:
* [`src/apax/apax-lock.json`](diffhunk://#diff-53cf8f66a20104b2e41a7a028b794b1e98ae64d1ce36c717b419a93a2c5a653aL10-R58): Upgraded `@ax/stc` package and its dependencies from version `8.0.17` to `9.1.36`.
* [`src/apax/apax.yml`](diffhunk://#diff-7f9e4c51355189467dfb8812cc4bfd510811f3e2955245871aa680441678324eL8-R8): Updated `@ax/stc` version from `8.0.17` to `9.1.36` in `devDependencies`.

### Attribute Annotation Adjustments:
* [`src/sanbox/integration/ix-integration-plc/ix/.g/POCO/*.g.cs`](diffhunk://#diff-f9e1ed36ea94afbb11d28c4eb14c00ad9d4ac72608abe1a1cb97fec84f94889eL7-R30): Replaced double quotes with verbatim string literals for `AttributeName` in multiple files. [[1]](diffhunk://#diff-f9e1ed36ea94afbb11d28c4eb14c00ad9d4ac72608abe1a1cb97fec84f94889eL7-R30) [[2]](diffhunk://#diff-fbf0f425812edbd1c8d8bc35a6d43828f1d9cd92b30f6eb623b029db0eb176b5L13-R19) [[3]](diffhunk://#diff-fbf0f425812edbd1c8d8bc35a6d43828f1d9cd92b30f6eb623b029db0eb176b5L31-R37) [[4]](diffhunk://#diff-fbf0f425812edbd1c8d8bc35a6d43828f1d9cd92b30f6eb623b029db0eb176b5L50-R56) [[5]](diffhunk://#diff-0b91dd8da1b59b8dfe8bcde8a4cf05a5a186e8adcb35b4a74227dd763ba549a2L15-R24) [[6]](diffhunk://#diff-0b91dd8da1b59b8dfe8bcde8a4cf05a5a186e8adcb35b4a74227dd763ba549a2L34-R43) [[7]](diffhunk://#diff-79cb089620bd64f2dd6510bf0a42320331ddf5a4ff96edad16f0aef907b5be6dL13-R46) [[8]](diffhunk://#diff-7e7554254edfef378d218fa32c52aceb1c3a0dfaf6980edaa50c2f892de086a9L13-R46) [[9]](diffhunk://#diff-155bcf72e31f96a9efd807f43d16cae359f9a35260c2fcd20e737e06fdb34f34L13-R46)

closes #396