### PR TITLE
fix attributed commands names

### DIFF
--- a/src/AXSharp.compiler/src/ixd/apax.yml
+++ b/src/AXSharp.compiler/src/ixd/apax.yml
@@ -21,7 +21,7 @@ files:
   - "bin/Release/net9.0/**"  
   - "!bin/Release/net9.0/.apax/.apax/**"  
 contributedCommands:
-  ixc:
+  ixd:
     bin: "bin/Release/net9.0/AXSharp.ixd.exe"
     description: "AX#Sharp documentation compiler"
     hidden: false

--- a/src/AXSharp.compiler/src/ixr/apax.yml
+++ b/src/AXSharp.compiler/src/ixr/apax.yml
@@ -21,7 +21,7 @@ files:
   - "bin/Release/net9.0/**"  
   - "!bin/Release/net9.0/.apax/.apax/**"  
 contributedCommands:
-  ixc:
+  ixr:
     bin: "bin/Release/net9.0/AXSharp.ixr.exe"
     description: "AX#Sharp resources compiler"
     hidden: false        


### PR DESCRIPTION
This pull request updates the `apax.yml` configuration files for the `ixd` and `ixr` projects to correct the contributed command names and their associated binaries. 

### Configuration updates:

* In `src/AXSharp.compiler/src/ixd/apax.yml`, the contributed command name was updated from `ixc` to `ixd`, and the binary path was updated to `AXSharp.ixd.exe` to reflect the correct documentation compiler.
* In `src/AXSharp.compiler/src/ixr/apax.yml`, the contributed command name was updated from `ixc` to `ixr`, and the binary path was updated to `AXSharp.ixr.exe` to reflect the correct resources compiler.