### PR TITLE
updates operon

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </GlobalPackageReference>
-    <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.44" />
+    <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.49" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
@@ -74,7 +74,6 @@
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="System.Interactive" Version="6.0.1" />
-    <PackageVersion Include="Operon" Version="0.2.0-alpha.44" />
+    <PackageVersion Include="System.Interactive" Version="6.0.1" />   
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates package versions in the `Directory.Packages.props` file to ensure compatibility and maintain up-to-date dependencies. The most significant changes involve upgrading the `Inxton.Operon` package and removing a duplicate `Operon` package entry.

### Dependency updates:

* Updated the `Inxton.Operon` package version from `0.2.0-alpha.44` to `0.2.0-alpha.49` to include the latest features and fixes. (`Directory.Packages.props`, [Directory.Packages.propsL12-R12](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L12-R12))

### Cleanup:

* Removed a duplicate `Operon` package entry (`0.2.0-alpha.44`) to avoid redundancy and potential conflicts. (`Directory.Packages.props`, [Directory.Packages.propsL78](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L78))