### PR TITLE
[BUG] Multiple non-eligible warning reported during compile

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -309,7 +309,7 @@ public static class SemanticsHelpers
     /// </summary>
     /// <param name="arrayTypeDeclaration"></param>
     /// <param name="sourceBuilder">Source builder</param>
-    /// <param name="warnMissingOrInconsistent">Should issue warnign if the type was not found though eligible.</param>
+    /// <param name="warnMissingOrInconsistent">Should issue warning if the type was not found though eligible.</param>
     /// <returns></returns>
     public static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, 
             ISourceBuilder sourceBuilder, 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -94,7 +94,7 @@ public static class SemanticsHelpers
 
             if (candidates.Count() > 1 && warnMissingOrInconsistent)
             {
-                Log.Logger.Warning($"{span?.Filename}({line}:{character}) : Multiple types found for '{typeAccess.TypeSymbol.Name}' the declaration appears ambiguous. You may need to fully qualify the declaration.");
+                Log.Logger.Warning($"{span?.Filename}({line}:{character}) : Multiple types found for '{typeAccess.TypeSymbol.Name}'. The declaration appears ambiguous. You may need to fully qualify the declaration.");
             }
         }
         catch

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -28,25 +28,30 @@ public static class SemanticsHelpers
     /// <param name="field">Field declaration</param>
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Lateral builder signature</param>
+    /// <param name="warnMissingOrInconsistent">Issues warning when the type is eligible but not available.</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligible, ITypeDeclaration eligibleType) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligible, ITypeDeclaration eligibleType) IsMemberEligibleForTranspile(this IFieldDeclaration field, ISourceBuilder sourceBuilder, 
+                                    string coBuilder = "", bool warnMissingOrInconsistent = false)
     {
-        var eligibility = field.IsEligibleForTranspile(sourceBuilder);
+        var eligibility = field.IsEligibleForTranspile(sourceBuilder, warnMissingOrInconsistent);
         var isEligible = (field.AccessModifier == AccessModifier.Public
                             && eligibility.isEligibe
                             && !IsToBeOmitted(field, sourceBuilder, coBuilder));
 
         return (isEligible, eligibility.eligibleType);
     }
-    
+
 
     /// <summary>
     /// Finds type declaration.
     /// </summary>
     /// <param name="compilation">Compilation object</param>
     /// <param name="typeAccess">Required type</param>
+    /// <param name="warnMissingOrInconsistent">Will report missing type.</param>
     /// <returns>Required type if found.</returns>
-    public static ITypeDeclaration FindTypeDeclaration(this Compilation compilation, AX.ST.Semantic.Model.ISemanticTypeAccess? typeAccess)
+    public static ITypeDeclaration FindTypeDeclaration
+            (this Compilation compilation, AX.ST.Semantic.Model.ISemanticTypeAccess? typeAccess, 
+                bool warnMissingOrInconsistent = false)
     {
         if (typeAccess == null)
             return null;
@@ -82,12 +87,12 @@ public static class SemanticsHelpers
             var span = typeAccess?.Location?.GetLineSpan();
             var line = span.Value.StartLinePosition.Line;
             var character = span.Value.StartLinePosition.Character;
-            if (candidates.Count() == 0)
+            if (candidates.Count() == 0 && warnMissingOrInconsistent)
             {
-                Log.Logger.Warning($"{span?.Filename}({line}:{character}) : Type '{typeAccess.TypeSymbol.Name}' not found the type may not be eligible for transpile or meta information is not available because this type is not defined in AX# compliant project. ");
+                Log.Logger.Warning($"{span?.Filename}({line}:{character}) : Type '{typeAccess.TypeSymbol.Name}' not found. The type may not be eligible for transpile or meta information is not available because this type is not defined in AX# compliant project.");
             }
 
-            if (candidates.Count() > 1)
+            if (candidates.Count() > 1 && warnMissingOrInconsistent)
             {
                 Log.Logger.Warning($"{span?.Filename}({line}:{character}) : Multiple types found for '{typeAccess.TypeSymbol.Name}' the declaration appears ambiguous. You may need to fully qualify the declaration.");
             }
@@ -101,7 +106,8 @@ public static class SemanticsHelpers
         return null;
     }
 
-    public static ITypeDeclaration FindTypeDeclaration(this Compilation compilation, IDeclaration? typeAccess)
+    private static ITypeDeclaration FindTypeDeclaration(this Compilation compilation, IDeclaration? typeAccess, 
+        bool warnMissingOrInconsistent = false)
     {
         // This is to resolve fully qualified type name when the type cannot be determined propeprly form the semantic tree.
         // TODO: This workaround should be removed once we can properly use project dependencies in the stc.
@@ -123,12 +129,12 @@ public static class SemanticsHelpers
             return candidates.First();
         }
 
-        if (candidates.Count() == 0)
+        if (candidates.Count() == 0 && warnMissingOrInconsistent)
         {
             Log.Logger.Warning($"Type '{typeAccess?.ToString()}' not found in the semantic tree. {typeAccess?.Location}");
         }
 
-        if (candidates.Count() > 1)
+        if (candidates.Count() > 1 && warnMissingOrInconsistent)
         {
             Log.Logger.Warning($"Multiple types found for '{typeAccess?.ToString()}' in the semantic tree. You may need to fully qualify the declaration.");
         }
@@ -136,7 +142,7 @@ public static class SemanticsHelpers
         return null;
     }
 
-    public static string? DetermineFullyQualifiedName(this AX.ST.Semantic.Model.ISemanticTypeAccess declaration, Compilation compilation)
+    private static string? DetermineFullyQualifiedName(this AX.ST.Semantic.Model.ISemanticTypeAccess declaration, Compilation compilation)
     {
         return compilation.FindTypeDeclaration(declaration)?.FullyQualifiedName;
     }
@@ -184,7 +190,7 @@ public static class SemanticsHelpers
     /// <param name="declaration">Field declaration</param>
     /// <param name="compilation">Compilation object.</param>
     /// <returns>Fully qualified name of the declaration.</returns>
-    public static string? DetermineFullyQualifiedName(this IFieldDeclaration declaration, Compilation compilation)
+    private static string? DetermineFullyQualifiedName(this IFieldDeclaration declaration, Compilation compilation)
     {
         return compilation.FindTypeDeclaration(declaration.TypeAccess)?.FullyQualifiedName;
     }
@@ -195,7 +201,7 @@ public static class SemanticsHelpers
     /// <param name="declaration">Variable declaration</param>
     /// <param name="compilation">Compilation object.</param>
     /// <returns>Fully qualified name of the declaration.</returns>
-    public static string? DetermineFullyQualifiedName(this IVariableDeclaration declaration, Compilation compilation)
+    private static string? DetermineFullyQualifiedName(this IVariableDeclaration declaration, Compilation compilation)
     {
         return compilation.FindTypeDeclaration(declaration.TypeAccess)?.FullyQualifiedName;
     }
@@ -243,11 +249,12 @@ public static class SemanticsHelpers
     /// </summary>
     /// <param name="fieldDeclaration"></param>
     /// <param name="sourceBuilder"></param>
+    /// <param name="warnMissingOrInconsistent">Issues warning when the type is eligible but not available.</param>
     /// <returns>True when the type is eligible</returns>
-    public static (bool isEligibe, ITypeDeclaration eligibleType) IsEligibleForTranspile(this IFieldDeclaration fieldDeclaration, ISourceBuilder sourceBuilder)
+    private static (bool isEligibe, ITypeDeclaration eligibleType) IsEligibleForTranspile(this IFieldDeclaration fieldDeclaration, ISourceBuilder sourceBuilder, bool warnMissingOrInconsistent = false)
     {
         var type = fieldDeclaration.Type;
-        var fullyQualified = sourceBuilder.Compilation.FindTypeDeclaration(fieldDeclaration.TypeAccess);
+        var fullyQualified = sourceBuilder.Compilation.FindTypeDeclaration(fieldDeclaration.TypeAccess, warnMissingOrInconsistent);
         var isEligible = !(type is IReferenceTypeDeclaration)
                 &&
                 fieldDeclaration.IsAvailableForComm(sourceBuilder)
@@ -271,11 +278,13 @@ public static class SemanticsHelpers
     /// </summary>
     /// <param name="variableDeclaration"></param>
     /// <param name="sourceBuilder"></param>
+    /// <param name="warnMissingOrInconsistent">Will issue warning when the type is eligible but not available.</param>
     /// <returns>True when the type is eligible</returns>
-    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IVariableDeclaration variableDeclaration, ISourceBuilder sourceBuilder)
+    private static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IVariableDeclaration variableDeclaration, 
+                        ISourceBuilder sourceBuilder, bool warnMissingOrInconsistent = false)
     {
         var type = variableDeclaration.Type;
-        var declaration = sourceBuilder.Compilation.FindTypeDeclaration(variableDeclaration.TypeAccess);
+        var declaration = sourceBuilder.Compilation.FindTypeDeclaration(variableDeclaration.TypeAccess, warnMissingOrInconsistent);
         var isEligible = !(type is IReferenceTypeDeclaration)
                &&
                variableDeclaration.IsAvailableForComm(sourceBuilder)
@@ -300,11 +309,14 @@ public static class SemanticsHelpers
     /// </summary>
     /// <param name="arrayTypeDeclaration"></param>
     /// <param name="sourceBuilder">Source builder</param>
+    /// <param name="warnMissingOrInconsistent">Should issue warnign if the type was not found though eligible.</param>
     /// <returns></returns>
-    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, ISourceBuilder sourceBuilder)
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsEligibleForTranspile(this IArrayTypeDeclaration arrayTypeDeclaration, 
+            ISourceBuilder sourceBuilder, 
+            bool warnMissingOrInconsistent = false )
     {
         var singleDimensionalArray = arrayTypeDeclaration.Dimensions.Count == 1;
-        var declaration = sourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess);
+        var declaration = sourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess, warnMissingOrInconsistent);
         var isEligibleType = !(arrayTypeDeclaration.ElementTypeAccess.Type is IReferenceTypeDeclaration)
                              &&
                              arrayTypeDeclaration.IsAvailableForComm(sourceBuilder)
@@ -326,10 +338,12 @@ public static class SemanticsHelpers
     /// <param name="variable">Variable declaration</param>
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Co-builder signature (e.g. POCO, Onliner, etc.)</param>
+    /// <param name="warnMissingOrInconsistent">Will issue waring when the type is eligible but not found</param>
     /// <returns>True when the member is eligible for generation.</returns>
-    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForTranspile(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
+    public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForTranspile(this IVariableDeclaration variable, 
+                                                    ISourceBuilder sourceBuilder, string coBuilder = "", bool warnMissingOrInconsistent = false)
     {
-        var eligibility = variable.IsEligibleForTranspile(sourceBuilder);
+        var eligibility = variable.IsEligibleForTranspile(sourceBuilder, warnMissingOrInconsistent);
         var eligible = variable.IsInGlobalMemory
                && eligibility.isEligibe
                && !IsToBeOmitted(variable, sourceBuilder, coBuilder);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -338,7 +338,7 @@ public static class SemanticsHelpers
     /// <param name="variable">Variable declaration</param>
     /// <param name="sourceBuilder">Source builder</param>
     /// <param name="coBuilder">Co-builder signature (e.g. POCO, Onliner, etc.)</param>
-    /// <param name="warnMissingOrInconsistent">Will issue waring when the type is eligible but not found</param>
+    /// <param name="warnMissingOrInconsistent">Will issue warning when the type is eligible but not found</param>
     /// <returns>True when the member is eligible for generation.</returns>
     public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForTranspile(this IVariableDeclaration variable, 
                                                     ISourceBuilder sourceBuilder, string coBuilder = "", bool warnMissingOrInconsistent = false)

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -32,7 +32,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateArrayTypeDeclaration(IArrayTypeDeclaration arrayTypeDeclaration, IxNodeVisitor visitor)
     {
-        var type = this.SourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess, true);
+        var type = this.SourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess, warnMissingOrInconsistent: true);
         //arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
         type.Accept(visitor, this);
         AddToSource("[]");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -170,7 +170,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    var arrayEligible = array.IsEligibleForTranspile(SourceBuilder, true);
+                    var arrayEligible = array.IsEligibleForTranspile(SourceBuilder, warnMissingOrInconsistent: true);
                     if (arrayEligible.isEligibe)
                     {
                         AddToSource($"public");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -76,7 +76,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    var arrayEligibility = array.IsEligibleForTranspile(SourceBuilder, true);
+                    var arrayEligibility = array.IsEligibleForTranspile(SourceBuilder, warnMissingOrInconsistent: true);
                     if (arrayEligibility.isEligibe)
                     {
                         AddToSource($"{fieldDeclaration.AccessModifier.Transform()} ");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs
@@ -32,7 +32,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateArrayTypeDeclaration(IArrayTypeDeclaration arrayTypeDeclaration, IxNodeVisitor visitor)
     {
-        var type = this.SourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess);
+        var type = this.SourceBuilder.Compilation.FindTypeDeclaration(arrayTypeDeclaration.ElementTypeAccess, true);
         //arrayTypeDeclaration.ElementTypeAccess.Type.Accept(visitor, this);
         type.Accept(visitor, this);
         AddToSource("[]");
@@ -51,7 +51,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder);
+        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, warnMissingOrInconsistent: true);
         if (eligibility.isEligible)
         {
             AddToSource(fieldDeclaration.Pragmas.AddAttributes());
@@ -76,7 +76,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    var arrayEligibility = array.IsEligibleForTranspile(SourceBuilder);
+                    var arrayEligibility = array.IsEligibleForTranspile(SourceBuilder, true);
                     if (arrayEligibility.isEligibe)
                     {
                         AddToSource($"{fieldDeclaration.AccessModifier.Transform()} ");
@@ -145,7 +145,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
 
     public void CreateVariableDeclaration(IVariableDeclaration semantics, IxNodeVisitor visitor)
     {
-        var eligibility = semantics.IsMemberEligibleForTranspile(SourceBuilder);
+        var eligibility = semantics.IsMemberEligibleForTranspile(SourceBuilder, warnMissingOrInconsistent: true);
         if (eligibility.isEligibe)
         {
             AddToSource(semantics.Pragmas.AddAttributes());
@@ -170,7 +170,7 @@ internal class CsOnlinerMemberBuilder : ICombinedThreeVisitor
                     AddToSource("{get;}");
                     break;
                 case IArrayTypeDeclaration array:
-                    var arrayEligible = array.IsEligibleForTranspile(SourceBuilder);
+                    var arrayEligible = array.IsEligibleForTranspile(SourceBuilder, true);
                     if (arrayEligible.isEligibe)
                     {
                         AddToSource($"public");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
@@ -160,7 +160,7 @@ public class CsOnlinerSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
         AX.ST.Semantic.Model.ISemanticTypeAccess? extendedType = classDeclaration.ExtendedTypeAccesses.FirstOrDefault();
 
         //TODO: Workaround for not fully qualified declarations. To be addressed with proper dependency handling in stc.
-        var extend = Compilation.FindTypeDeclaration(extendedType, true);
+        var extend = Compilation.FindTypeDeclaration(extendedType, warnMissingOrInconsistent: true);
         if (extend != null)
         {
             AddToSource($"{extend.FullyQualifiedName}{ReplaceGenericSignature(classDeclaration)}");

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs
@@ -160,7 +160,7 @@ public class CsOnlinerSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
         AX.ST.Semantic.Model.ISemanticTypeAccess? extendedType = classDeclaration.ExtendedTypeAccesses.FirstOrDefault();
 
         //TODO: Workaround for not fully qualified declarations. To be addressed with proper dependency handling in stc.
-        var extend = Compilation.FindTypeDeclaration(extendedType);
+        var extend = Compilation.FindTypeDeclaration(extendedType, true);
         if (extend != null)
         {
             AddToSource($"{extend.FullyQualifiedName}{ReplaceGenericSignature(classDeclaration)}");


### PR DESCRIPTION
This pull request enhances type-checking and eligibility determination in the `AXSharp.Cs.Compiler` by introducing a `warnMissingOrInconsistent` parameter to several methods. This parameter enables logging warnings when types are eligible but missing or inconsistent. Additionally, some methods were made `private` to improve encapsulation.

### Enhancements to type-checking and eligibility determination:

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs`](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R31-R36): Added a `warnMissingOrInconsistent` parameter to methods like `IsMemberEligibleForTranspile`, `FindTypeDeclaration`, and `IsEligibleForTranspile` to log warnings for missing or ambiguous types. This improves debugging and transparency during transpilation. [[1]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R31-R36) [[2]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R50-R54) [[3]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L85-R95) [[4]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R252-R257) [[5]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R281-R287) [[6]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R312-R319) [[7]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106R341-R346)

### Improvements in encapsulation:

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs`](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L104-R110): Changed access modifiers of methods like `DetermineFullyQualifiedName` and `FindTypeDeclaration` to `private` to restrict their usage within the class, ensuring better encapsulation. [[1]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L104-R110) [[2]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L187-R193) [[3]](diffhunk://#diff-7a279460dbf2bc1dfc10b83131a002e6ec9e738d8ea74ee65d2dd48a884a7106L198-R204)

### Updates to dependent code:

* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerMemberBuilder.cs`](diffhunk://#diff-feea605a5e73e13b9c86b7ddef287c294776b4309346e9edaa1a2f36f93f5c9bL35-R35): Updated calls to methods such as `FindTypeDeclaration` and `IsMemberEligibleForTranspile` to pass the `warnMissingOrInconsistent` parameter set to `true`, ensuring warnings are logged during member creation processes. [[1]](diffhunk://#diff-feea605a5e73e13b9c86b7ddef287c294776b4309346e9edaa1a2f36f93f5c9bL35-R35) [[2]](diffhunk://#diff-feea605a5e73e13b9c86b7ddef287c294776b4309346e9edaa1a2f36f93f5c9bL54-R54) [[3]](diffhunk://#diff-feea605a5e73e13b9c86b7ddef287c294776b4309346e9edaa1a2f36f93f5c9bL79-R79) [[4]](diffhunk://#diff-feea605a5e73e13b9c86b7ddef287c294776b4309346e9edaa1a2f36f93f5c9bL148-R148) [[5]](diffhunk://#diff-feea605a5e73e13b9c86b7ddef287c294776b4309346e9edaa1a2f36f93f5c9bL173-R173)
* [`src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerSourceBuilder.cs`](diffhunk://#diff-2fc3a7a6d94d7a82875d4214f98bb5d7feba67c3f660e5203c1a07db00162a48L163-R163): Modified the `FindTypeDeclaration` call in `CreateClassDeclaration` to include the `warnMissingOrInconsistent` parameter for extended type handling.

closes #421