### PR TITLE
[BUG] IXC Parsing csproj files does not take attribs into consideration.

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/CsProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/CsProject.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging;
 using NuGet.Versioning;
 using Polly;
 using Serilog.Core;
+using System.Text.RegularExpressions;
 
 namespace AXSharp.Compiler;
 
@@ -77,7 +78,7 @@ public class CsProject : ITargetProject
     {
         var fileName = string.Empty;
 
-        if (SyntaxFacts.IsIdentifierPartCharacter(name.FirstOrDefault())) fileName = $"{name.FirstOrDefault()}";
+        if (SyntaxFacts.IsIdentifierPartCharacter(name.FirstOrDefault())) fileName = $"{name.FirstOrDefault()}" ;
 
         for (var i = 1; i < name.Length; i++)
         {
@@ -176,7 +177,7 @@ public class CsProject : ITargetProject
 
     private static readonly string NugetDir =
         SettingsUtility.GetGlobalPackagesFolder(Settings.LoadDefaultSettings(null));
-
+    
 
     /// <inheritdoc />
     public void ProvisionProjectStructure()
@@ -398,8 +399,10 @@ namespace {this.ProjectRootNamespace}
         {
             var csproj = XDocument.Load(projectPath);
             var csprojDir = FileDirectory(projectFile);
-            var nugets = PackageReferences(csproj, projectFile);
-            var projects = ProjectReferences(csproj, csprojDir);
+            // Collect MSBuild properties (Directory.Build.props + project)
+            var (baseProperties, targetFrameworks) = MsBuildConditionEvaluator.CollectBaseProperties(projectPath, csproj);
+            var nugets = PackageReferences(csproj, projectPath, targetFrameworks, baseProperties);
+            var projects = ProjectReferences(csproj, csprojDir, targetFrameworks, baseProperties);
             return nugets.Concat(projects);
         }
         catch (Exception ex)
@@ -470,8 +473,9 @@ namespace {this.ProjectRootNamespace}
         {
             var csproj = XDocument.Load(project.ProjectFilePath);
             var csprojDir = FileDirectory(project.ProjectFilePath);
-            var nugets = PackageReferences(csproj, project.ProjectFilePath);
-            var projects = ProjectReferences(csproj, csprojDir);
+            var (baseProps, tfs) = MsBuildConditionEvaluator.CollectBaseProperties(project.ProjectFilePath, csproj);
+            var nugets = PackageReferences(csproj, project.ProjectFilePath, tfs, baseProps);
+            var projects = ProjectReferences(csproj, csprojDir, tfs, baseProps);
             project.References = nugets.Concat(projects);
             return project.References;
         }
@@ -483,13 +487,30 @@ namespace {this.ProjectRootNamespace}
         }
     }
 
-    private static IEnumerable<IReference> PackageReferences(XDocument csproj, string projectFile)
+    private static IEnumerable<IReference> PackageReferences(XDocument csproj, string projectFile, IEnumerable<string> targetFrameworks, Dictionary<string,string> baseProperties)
     {
-        return csproj
-            .Root!
-            .Elements("ItemGroup")
-            .SelectMany(ig => ig.Elements("PackageReference"))
-            .Select(pr => PackageReference.CreateFromReferenceNode(pr, projectFile));
+        var result = new List<IReference>();
+        var itemGroups = csproj.Root!.Elements("ItemGroup");
+        foreach (var ig in itemGroups)
+        {
+            foreach (var tf in targetFrameworks)
+            {
+                if (!MsBuildConditionEvaluator.ItemGroupConditionPasses(ig, baseProperties, tf)) continue;
+                foreach (var pr in ig.Elements("PackageReference"))
+                {
+                    if (!MsBuildConditionEvaluator.ElementConditionPasses(pr, baseProperties, tf)) continue;
+                    try
+                    {
+                        result.Add(PackageReference.CreateFromReferenceNode(pr, projectFile));
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Logger.Warning(e, $"Failed to parse PackageReference '{pr}' in '{projectFile}'");
+                    }
+                }
+            }
+        }
+        return result;
     }
 
     private static string PackageReferenceNugetPath(PackageReference package)
@@ -523,13 +544,25 @@ namespace {this.ProjectRootNamespace}
        
     }
 
-    private static IEnumerable<IReference> ProjectReferences(XDocument csproj, string directory)
+    private static IEnumerable<IReference> ProjectReferences(XDocument csproj, string directory, IEnumerable<string> targetFrameworks, Dictionary<string,string> baseProperties)
     {
-        return csproj
-            .Root!
-            .Elements("ItemGroup")
-            .SelectMany(ig => ig.Elements("ProjectReference"))
-            .Select(pr => new ProjectReference(directory, pr.Attribute("Include")!.Value.Replace("\\",Path.DirectorySeparatorChar.ToString())));
+        var result = new List<IReference>();
+        var itemGroups = csproj.Root!.Elements("ItemGroup");
+        foreach (var ig in itemGroups)
+        {
+            foreach (var tf in targetFrameworks)
+            {
+                if (!MsBuildConditionEvaluator.ItemGroupConditionPasses(ig, baseProperties, tf)) continue;
+                foreach (var pr in ig.Elements("ProjectReference"))
+                {
+                    if (!MsBuildConditionEvaluator.ElementConditionPasses(pr, baseProperties, tf)) continue;
+                    var include = pr.Attribute("Include")?.Value.Replace("\\",Path.DirectorySeparatorChar.ToString());
+                    if (string.IsNullOrWhiteSpace(include)) continue;
+                    result.Add(new ProjectReference(directory, include));
+                }
+            }
+        }
+        return result;
     }
 
     #endregion
@@ -562,5 +595,231 @@ namespace {this.ProjectRootNamespace}
                 CompanionInfo.ToFile(new CompanionInfo() { Id = packageId, Version = this.AxSharpProject.AxProject.ProjectInfo.Version }, Path.Combine(this.AxSharpProject.AxProject.ProjectFolder, CompanionInfo.COMPANIONS_FILE_NAME));
             }
         }
+    }
+
+    /// <summary>
+    /// Helper class for naïve MSBuild condition evaluation for dependency discovery.
+    /// Supports equality/inequality with $(Property) and logical AND/OR operators.
+    /// Only properties needed for typical ItemGroup conditions are handled (TargetFramework / Configuration etc.).
+    /// </summary>
+    private static class MsBuildConditionEvaluator
+    {
+        internal static (Dictionary<string,string> properties, List<string> targetFrameworks) CollectBaseProperties(string projectFile, XDocument csproj)
+        {
+            var props = new Dictionary<string,string>(StringComparer.OrdinalIgnoreCase);
+
+            // Walk up directories gathering Directory.Build.props (outermost first)
+            var dir = Path.GetDirectoryName(projectFile)!;
+            var stack = new Stack<string>();
+            var current = dir;
+            while (!string.IsNullOrEmpty(current))
+            {
+                var dbp = Path.Combine(current, "Directory.Build.props");
+                if (File.Exists(dbp)) stack.Push(dbp);
+                var parent = Directory.GetParent(current);
+                if (parent == null) break;
+                current = parent.FullName;
+            }
+
+            foreach (var dbp in stack)
+            {
+                TryLoadProps(dbp, props);
+            }
+
+            // Project properties override
+            TryLoadProjectProperties(csproj, props);
+
+            // Derive target frameworks (TargetFramework overrides TargetFrameworks if present)
+            var frameworks = new List<string>();
+            if (props.TryGetValue("TargetFramework", out var singleTf) && !string.IsNullOrWhiteSpace(singleTf))
+            {
+                frameworks.Add(singleTf.Trim());
+            }
+            else if (props.TryGetValue("TargetFrameworks", out var tfs) && !string.IsNullOrWhiteSpace(tfs))
+            {
+                frameworks.AddRange(tfs.Split(new[]{';'}, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+            }
+            if (frameworks.Count == 0)
+            {
+                // default fallback
+                frameworks.Add("netstandard2.0");
+            }
+            return (props, frameworks);
+        }
+
+        private static void TryLoadProps(string file, Dictionary<string,string> props)
+        {
+            try
+            {
+                var x = XDocument.Load(file);
+                TryLoadProjectProperties(x, props);
+            }
+            catch { /* ignore */ }
+        }
+
+        private static void TryLoadProjectProperties(XDocument xdoc, Dictionary<string,string> props)
+        {
+            foreach (var pg in xdoc.Root!.Elements("PropertyGroup"))
+            {
+                // Ignore conditional property groups for now (most TF definitions are unconditional in props files)
+                foreach (var el in pg.Elements())
+                {
+                    if (!el.HasElements && !string.IsNullOrWhiteSpace(el.Value))
+                    {
+                        props[el.Name.LocalName] = el.Value.Trim();
+                    }
+                }
+            }
+        }
+
+        internal static bool ItemGroupConditionPasses(XElement itemGroup, Dictionary<string,string> baseProps, string targetFramework)
+            => ConditionPasses(itemGroup.Attribute("Condition")?.Value, baseProps, targetFramework);
+
+        internal static bool ElementConditionPasses(XElement element, Dictionary<string,string> baseProps, string targetFramework)
+        {
+            var condition = element.Attribute("Condition")?.Value;
+            var passes = ConditionPasses(condition, baseProps, targetFramework);
+            if (!string.IsNullOrWhiteSpace(condition))
+            {
+                try
+                {
+                    var include = element.Attribute("Include")?.Value;
+                    Log.Logger.Debug($"[MsBuildConditionEvaluator] Element '{element.Name.LocalName}' Include='{include}' condition='{condition}' tf='{targetFramework}' => {passes}");
+                }
+                catch { /* ignore */ }
+            }
+            return passes;
+        }
+
+        private static bool ConditionPasses(string? condition, Dictionary<string,string> baseProps, string targetFramework)
+        {
+            if (string.IsNullOrWhiteSpace(condition)) return true;
+            try
+            {
+                // Fast path for simple TF equality/inequality expressions to avoid parser quirks
+                var simpleTfEq = Regex.Match(condition, @"^\s*'\$\(TargetFramework\)'\s*==\s*'([^']+)'\s*$", RegexOptions.IgnoreCase);
+                if (simpleTfEq.Success)
+                {
+                    var expected = simpleTfEq.Groups[1].Value.Trim();
+                    var ok = string.Equals(expected, targetFramework, StringComparison.OrdinalIgnoreCase);
+                    Log.Logger.Debug($"[MsBuildConditionEvaluator] simple == TF condition '{condition}' => {ok}");
+                    if (!ok) return false; // short circuit
+                }
+                var simpleTfNe = Regex.Match(condition, @"^\s*'\$\(TargetFramework\)'\s*!=\s*'([^']+)'\s*$", RegexOptions.IgnoreCase);
+                if (simpleTfNe.Success)
+                {
+                    var notExpected = simpleTfNe.Groups[1].Value.Trim();
+                    var ok = !string.Equals(notExpected, targetFramework, StringComparison.OrdinalIgnoreCase);
+                    Log.Logger.Debug($"[MsBuildConditionEvaluator] simple != TF condition '{condition}' => {ok}");
+                    if (!ok) return false; // short circuit
+                }
+
+                var expanded = condition;
+                var props = new Dictionary<string,string>(baseProps, StringComparer.OrdinalIgnoreCase)
+                {
+                    ["TargetFramework"] = targetFramework
+                };
+                foreach (var kvp in props)
+                {
+                    expanded = expanded.Replace($"$({kvp.Key})", kvp.Value, StringComparison.OrdinalIgnoreCase);
+                }
+                var result = Evaluate(expanded);
+                if (expanded.Contains("=="))
+                {
+                    var parts = expanded.Split(new[]{"=="}, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    if (parts.Length == 2)
+                    {
+                        var left = NormalizeLiteral(parts[0]);
+                        var right = NormalizeLiteral(parts[1]);
+                        result = string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+                else if (expanded.Contains("!="))
+                {
+                    var parts = expanded.Split(new[]{"!="}, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    if (parts.Length == 2)
+                    {
+                        var left = NormalizeLiteral(parts[0]);
+                        var right = NormalizeLiteral(parts[1]);
+                        result = !string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+                Log.Logger.Debug($"[MsBuildConditionEvaluator] expanded='{expanded}' tf='{targetFramework}' => {result}");
+                return result;
+            }
+            catch (Exception e)
+            {
+                Log.Logger.Debug(e, $"Failed to evaluate MSBuild condition '{condition}'. Assuming false.");
+                return false;
+            }
+        }
+
+        private static bool Evaluate(string expr)
+        {
+            // Very small parser: handle parentheses removal, quotes, ==, !=, And/Or
+            expr = expr.Trim();
+            if (expr.StartsWith("(") && expr.EndsWith(")"))
+            {
+                expr = expr.Substring(1, expr.Length - 2).Trim();
+            }
+
+            // Split by OR
+            var orParts = Split(expr, new[]{" Or ", " or ", " OR "});
+            if (orParts.Length > 1)
+            {
+                return orParts.Any(p => Evaluate(p));
+            }
+            var andParts = Split(expr, new[]{" And ", " and ", " AND "});
+            if (andParts.Length > 1)
+            {
+                return andParts.All(p => Evaluate(p));
+            }
+
+            // Equality / inequality
+            if (expr.Contains("!="))
+            {
+                var sides = expr.Split(new[]{"!="}, StringSplitOptions.RemoveEmptyEntries);
+                if (sides.Length == 2)
+                {
+                    return !NormalizeLiteral(sides[0]).Equals(NormalizeLiteral(sides[1]), StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            if (expr.Contains("=="))
+            {
+                var sides = expr.Split(new[]{"=="}, StringSplitOptions.RemoveEmptyEntries);
+                if (sides.Length == 2)
+                {
+                    return NormalizeLiteral(sides[0]).Equals(NormalizeLiteral(sides[1]), StringComparison.OrdinalIgnoreCase);
+                }
+            }
+
+            // If cannot parse, default true (MSBuild would treat non-empty?) but safer false.
+            return false;
+        }
+
+        private static string NormalizeLiteral(string val)
+        {
+            val = val.Trim();
+            if (val.StartsWith("'")) val = val.Trim('\'');
+            if (val.StartsWith("\"")) val = val.Trim('"');
+            return val.Trim();
+        }
+
+        private static string[] Split(string expr, string[] separators)
+        {
+            foreach (var sep in separators)
+            {
+                var idx = IndexOfIgnoreCase(expr, sep);
+                if (idx >= 0)
+                {
+                    // simple split (no nested support)
+                    return expr.Split(separators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                }
+            }
+            return new[]{expr};
+        }
+
+        private static int IndexOfIgnoreCase(string source, string value)
+            => source.IndexOf(value, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Integration.Cs/IxProjectTests.IntegrationCs.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/Integration.Cs/IxProjectTests.IntegrationCs.cs
@@ -10,7 +10,6 @@ using AXSharp.Compiler;
 using AXSharp.Compiler.Cs.Onliner;
 using AXSharp.Compiler.Cs.Plain;
 using AXSharp.Compiler.CsTests;
-using Castle.Core.Resource;
 using Polly;
 using Xunit.Abstractions;
 

--- a/src/AXSharp.compiler/tests/AXSharp.CompilerTests/AXSharp.CompilerTests.csproj
+++ b/src/AXSharp.compiler/tests/AXSharp.CompilerTests/AXSharp.CompilerTests.csproj
@@ -39,8 +39,6 @@
 		</PackageReference>
 	</ItemGroup>
 
-
-	
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\AXSharp.Compiler\AXSharp.Compiler.csproj" />
 		<ProjectReference Include="..\..\src\AXSharp.Cs.Compiler\AXSharp.Compiler.Cs.csproj" />
@@ -51,6 +49,9 @@
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>
     <Content Include="samples\plt\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="samples\conditional\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
 	</ItemGroup>

--- a/src/AXSharp.compiler/tests/AXSharp.CompilerTests/ConditionalDependenciesTests.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.CompilerTests/ConditionalDependenciesTests.cs
@@ -1,0 +1,133 @@
+using System.Reflection;
+using AXSharp.Compiler;
+using Xunit;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace AXSharp.CompilerTests;
+
+public class ConditionalDependenciesTests
+{
+    private readonly string _root;
+    private const string ExpectedCsProjFile = "conditional_test.csproj"; // derived from apax name 'conditional-test'
+
+    public ConditionalDependenciesTests()
+    {
+        var fi = new FileInfo(Assembly.GetExecutingAssembly().Location);
+        _root = Path.Combine(fi.Directory!.FullName, "samples", "conditional");
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public void should_respect_itemgroup_condition_targetframework()
+    {
+        var projDir = Path.Combine(_root, "tfm");
+        if (Directory.Exists(projDir)) Directory.Delete(projDir, true);
+        Directory.CreateDirectory(projDir);
+
+        // minimal src structure required by AxProject
+        PrepareSrc(projDir);
+        EnsureApax(projDir);
+
+        var csproj = """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="PkgOnlyNet8" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
+    <PackageReference Include="PkgOnlyNet9" Version="2.0.0" />
+  </ItemGroup>
+</Project>
+""";
+        File.WriteAllText(Path.Combine(projDir, ExpectedCsProjFile), csproj);
+
+        var ax = new AXSharpProject(new AxProject(projDir), Array.Empty<Type>(), typeof(CsProject), new CompilerTestOptions(){ OutputProjectFolder = projDir});
+        var target = (CsProject)ax.TargetProject;
+        var refs = target.LoadReferences().OfType<PackageReference>().ToList();
+        Assert.Contains(refs, r => r.Include == "PkgOnlyNet8");
+        Assert.Contains(refs, r => r.Include == "PkgOnlyNet9");
+    }
+
+    [Fact]
+    public void should_respect_element_condition_inside_itemgroup()
+    {
+        var projDir = Path.Combine(_root, "element");
+        if (Directory.Exists(projDir)) Directory.Delete(projDir, true);
+        Directory.CreateDirectory(projDir);
+        PrepareSrc(projDir);
+        EnsureApax(projDir);
+
+        var csproj = """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AlwaysPkg" Version="1.0.0" />
+    <PackageReference Include="CondPkg" Version="1.2.3" Condition="'$(TargetFramework)'=='net8.0'" />
+    <PackageReference Include="SkippedPkg" Version="3.0.0" Condition="'$(TargetFramework)'=='net9.0'" />
+  </ItemGroup>
+</Project>
+""";
+        File.WriteAllText(Path.Combine(projDir, ExpectedCsProjFile), csproj);
+
+        var ax = new AXSharpProject(new AxProject(projDir), Array.Empty<Type>(), typeof(CsProject), new CompilerTestOptions(){ OutputProjectFolder = projDir});
+        var target = (CsProject)ax.TargetProject;
+        var refs = target.LoadReferences().OfType<PackageReference>().ToList();
+        Assert.Contains(refs, r => r.Include == "AlwaysPkg");
+        Assert.Contains(refs, r => r.Include == "CondPkg");
+        Assert.DoesNotContain(refs, r => r.Include == "SkippedPkg");
+    }
+
+    [Fact]
+    public void should_merge_directory_build_props_properties()
+    {
+        var projDir = Path.Combine(_root, "dbp");
+        if (Directory.Exists(projDir)) Directory.Delete(projDir, true);
+        Directory.CreateDirectory(projDir);
+        PrepareSrc(projDir);
+        EnsureApax(projDir);
+
+        File.WriteAllText(Path.Combine(projDir, "Directory.Build.props"), """
+<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>
+""");
+
+        var csproj = """
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>ConditionalDbp</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+    <PackageReference Include="DbpPkg" Version="4.5.6" />
+  </ItemGroup>
+</Project>
+""";
+        File.WriteAllText(Path.Combine(projDir, ExpectedCsProjFile), csproj);
+
+        var ax = new AXSharpProject(new AxProject(projDir), Array.Empty<Type>(), typeof(CsProject), new CompilerTestOptions(){ OutputProjectFolder = projDir});
+        var target = (CsProject)ax.TargetProject;
+        var refs = target.LoadReferences().OfType<PackageReference>().ToList();
+        Assert.Contains(refs, r => r.Include == "DbpPkg");
+    }
+
+    private static void EnsureApax(string dir)
+    {
+        var apax = Path.Combine(dir, "apax.yml");
+        if (!File.Exists(apax))
+        {
+            File.WriteAllText(apax, "name: conditional-test\nversion: 0.0.1\n");
+        }
+    }
+
+    private static void PrepareSrc(string dir)
+    {
+        var src = Path.Combine(dir, "src");
+        Directory.CreateDirectory(src);
+        // minimal dummy ST file
+        File.WriteAllText(Path.Combine(src, "_dummy.st"), "PROGRAM DUMMY\nEND_PROGRAM");
+    }
+}


### PR DESCRIPTION
Summary of PR #436

Title: [BUG] IXC Parsing csproj files does not take attribs into consideration.

Implements conditional-aware csproj dependency parsing (handling Condition attributes, multi-target frameworks, and property aggregation) to fix missing references.

Purpose: Fixes incorrect dependency discovery where conditional PackageReference / ProjectReference entries (with Condition attributes or within conditional ItemGroup blocks) were previously ignored. Closes issue #435.

Key Changes:

Adds a lightweight MsBuildConditionEvaluator embedded in CsProject.cs:
Collects properties from cascading [Directory.Build.props](vscode-file://vscode-app/c:/Users/peto.kurhajec/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) plus the project’s PropertyGroup elements.
Derives TargetFramework / TargetFrameworks (falls back to netstandard2.0 if absent).
Evaluates simple Condition expressions (==, !=, And, Or) with $(Property) expansion (not a full MSBuild interpreter).
Applies condition checks to ItemGroup, PackageReference, and ProjectReference nodes.
Refactors PackageReferences(...) and ProjectReferences(...) to iterate per target framework and filter by passing conditions.
Adds debug logging for condition evaluation and guarded failure logging on bad PackageReference parsing.
Adds handling for multi-target frameworks and basic property precedence.
Test project updated:
Adds new conditional sample content (samples/conditional/**) copied to output.
Introduces / updates tests (e.g., ConditionalDependenciesTests.cs) to assert conditional dependency resolution.
Removes unused Castle.Core.Resource using.
Minor cosmetic/whitespace adjustments.
Files Changed (4 total):

CsProject.cs (major: +~300 lines; new evaluator + refactors).
ConditionalDependenciesTests.cs (new or expanded tests for conditional references).
AXSharp.CompilerTests.csproj (adds conditional sample content include).
IxProjectTests.IntegrationCs.cs (removes unused using).
Diff Stats: Approx. +413 / -21 overall (dominant additions in CsProject.cs).

Benefits:

Correctly includes/excludes dependencies based on common Condition patterns.
Supports multi-target evaluation to gather the union of conditional dependencies.
Improves resilience (try/catch around individual PackageReference parsing).
Limitations / Risks:

Condition evaluator is naïve: no support for complex MSBuild functions, property redefinitions inside conditional PropertyGroups, string operations, Exists(), etc.
Defaults netstandard2.0 if no TF specified—could mask configuration issues.
Logical parsing is simplistic (no nested parentheses beyond single outer removal; may mis-handle complex mixed AND/OR precedence).
Returns false on evaluation exceptions (could hide valid references if a condition is slightly more complex).
Review Suggestions:

Consider unit tests covering mixed And/Or with parentheses, inequality cases, multiple TargetFrameworks, and ignored conditional PropertyGroup overrides.
Validate behavior when both TargetFramework and TargetFrameworks exist (current logic prefers single TF—intended?).
Assess whether returning false on evaluation failure is too strict; maybe fallback to true with a warning?
Potential extraction of MsBuildConditionEvaluator into its own file for clarity and future extension.
Follow-Up Opportunities:

Expand condition parser (parentheses nesting, property redefinitions, common MSBuild functions).
Cache property evaluation results per project to reduce repeated parsing.
Add verbose mode toggle for debug logs.
Status: Open, 2 commits, marked ready for review, awaiting at least one approval. No labels assigned yet.


closes #435