### PR TITLE
[BUG] Bulk write method may write ro members

### DIFF
--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
@@ -475,7 +475,8 @@ public class WebApiConnector : Connector
         if (primitives == null || !primitives.Any()) return;
 
         var responseData = new ApiBulkResponse();
-        var twinPrimitives = primitives as ITwinPrimitive[] ?? primitives.ToArray();
+        var writeEnabledPrimitives = primitives.Where(p => p.ReadWriteAccess == ReadWriteAccess.ReadWrite);
+        var twinPrimitives = writeEnabledPrimitives as ITwinPrimitive[] ?? writeEnabledPrimitives.ToArray();
 
         if (Logger.IsEnabled(LogEventLevel.Debug)) stopwatchWrite.Restart();
 

--- a/src/scripts/check_requisites_apax.sh
+++ b/src/scripts/check_requisites_apax.sh
@@ -1,5 +1,5 @@
 apaxUrl="https://console.simatic-ax.siemens.io/"
-expectedApaxVersion="3.5.0"
+expectedApaxVersion="4.0.0"
 
 export GREEN='\033[0;32m'
 export RED='\033[0;31m'

--- a/src/scripts/sw_build_and_download_delta.sh
+++ b/src/scripts/sw_build_and_download_delta.sh
@@ -39,7 +39,7 @@ if [ -z $PASSWORD ]; then
     exit 1
 fi
 
-apax build --ignore-scripts
+apax build
 dotnet ixc
 
 #sw_download_delta

--- a/src/scripts/sw_build_and_download_full.sh
+++ b/src/scripts/sw_build_and_download_full.sh
@@ -39,7 +39,7 @@ if [ -z $PASSWORD ]; then
     exit 1
 fi
 
-apax build --ignore-scripts
+apax build
 dotnet ixc
 
 #sw_download_full


### PR DESCRIPTION
This pull request includes several updates to improve compatibility with the latest tools and ensure correct write operations in the WebAPI connector. The most significant changes are grouped below:

**Tooling and Script Updates:**

* Updated the expected `apax` version to `4.0.0` in `check_requisites_apax.sh` to ensure compatibility with the latest tooling.
* Removed the `--ignore-scripts` flag from the `apax build` command in both `sw_build_and_download_delta.sh` and `sw_build_and_download_full.sh`, allowing build scripts to run as intended during the build process. [[1]](diffhunk://#diff-db10233886d8b0c5e61006f364e83dc18ee5b329d2d8b77d3979de5d7c3f628bL42-R42) [[2]](diffhunk://#diff-537c6ab64ee9a88e4120d5cdf87764a998322b8ce0629f25e6c8e0e22001ea65L42-R42)

**WebAPI Connector Logic:**

* Modified `WriteBatchAsync` in `WebApiConnector.cs` to filter primitives so that only those with `ReadWriteAccess.ReadWrite` are processed for writing, preventing unintended write attempts to read-only primitives.

closes #438