### PR TITLE
[feat] Split checking reading and assingin identities

### DIFF
--- a/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector.S71500.WebAPI/WebApiConnector.cs
@@ -51,6 +51,8 @@ public class WebApiConnector : Connector
         int maxConcurrentRequest = 4,
         int concurrentRequestDelay = 0)
     {
+        Logger?.Information($"Attempting to connect to '{ipAddress}'");
+
         IPAddress = ipAddress;
         DBName = dbName;
         TargetPlatform = platform;
@@ -96,6 +98,8 @@ public class WebApiConnector : Connector
         int maxConcurrentRequest = 4,
         int concurrentRequestDelay = 0)
     {
+        Logger?.Information($"Attempting to connect to '{ipAddress}'");
+
         IPAddress = ipAddress;
         DBName = dbName;
         TargetPlatform = platform;
@@ -110,6 +114,7 @@ public class WebApiConnector : Connector
                 (sender, cert, chain, sslPolicyErrors) => true;
 
         var serviceFactory = new ApiStandardServiceFactory();
+       
         Client = serviceFactory.GetHttpClient(ipAddress, UserName, UserPassword ?? string.Empty);
 
         var splitter = new ApiRequestSplitterByBytes();

--- a/src/AXSharp.connectors/src/AXSharp.Connector/Identity/TwinIdentityProvider.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/Identity/TwinIdentityProvider.cs
@@ -193,27 +193,6 @@ public class TwinIdentityProvider
         {
             _connector.Logger.Information("Reading identities...");
             await _connector.ReadBatchAsync(_identitiesTags);
-            var lastIdentity = 0ul;
-            if (_identitiesTags.Count > 0)
-            {
-                lastIdentity = _identitiesTags.Max(p => p.LastValue);
-            }
-
-            List<ITwinPrimitive> IdentitiesToWrite = new();
-
-            _connector.Logger.Information("Assigning missing identities...");
-            foreach (var it in _identitiesTags)
-            {
-                if (it.LastValue == 0)
-                {
-                    it.Cyclic = ++lastIdentity;
-                    IdentitiesToWrite.Add(it);  
-                }
-               
-            }
-            await _connector.WriteBatchAsync(IdentitiesToWrite);
-
-            _connector.Logger.Information("Reading identities done.");
             _connector.Logger.Information(
                 $"Number of identities: {_identitiesTags.Count} | Unique :{_identities.Count}");
         }
@@ -221,12 +200,45 @@ public class TwinIdentityProvider
         return _identitiesTags;
     }
 
+
+    /// <summary>
+    /// Assigns identities to all elements.
+    /// </summary>
+    /// <param name="identities">Identities</param>
+    /// <param name="identityProvider">Identity creator.</param>
+    /// <returns></returns>
+    public IEnumerable<OnlinerULInt> AssignIdentities(IEnumerable<OnlinerULInt> identities, Func<OnlinerULInt, ulong> identityProvider = null)
+    {
+        // If no identity provider is given, use default one based on hash code of the symbol.
+        identityProvider ??= (x) => x.Cyclic = (ulong)x.Symbol.GetHashCode();
+
+        _connector.Logger.Information("Assigning missing identities...");
+        foreach (var it in identities)
+        {
+            it.Cyclic = identityProvider(it);
+        }
+
+        return identities;
+    }
+
+    /// <summary>
+    /// Writes identities to the PLC.
+    /// </summary>
+    /// <param name="identitiesToWrite">List of identities to be written.</param>
+    /// <returns></returns>
+    public async Task WriteIdentities(IEnumerable<OnlinerULInt> identitiesToWrite)
+    {
+        if(_connector == null) return;
+        await _connector.WriteBatchAsync(identitiesToWrite);
+        _connector.Logger.Information("Identities have been written.");
+    }
+
     /// <summary>
     ///     Refreshes and sorts identities.
     /// </summary>
-    public async Task ConstructIdentitiesAsync()
+    public async Task ConstructIdentitiesAsync(Func<OnlinerULInt, ulong> identityProvider = null)
     {
-        await ReadIdentitiesAsync();
+        await WriteIdentities(AssignIdentities(await ReadIdentitiesAsync(), identityProvider));
         await SortIdentitiesAsync();
     }
 
@@ -243,10 +255,29 @@ public class TwinIdentityProvider
             {
                 var key = identity.Key.LastValue == 0 ? identity.Key.GetAsync().Result : identity.Key.LastValue;
                 if (!_sortedIdentities.ContainsKey(key))
+                {
                     _sortedIdentities.Add(key, identity.Value);
+                }
+                else
+                {
+                    throw new DuplicateIdentityException("There is a duplicate identity: " +
+                                                         $"{identity.Value.Symbol} : {key}." +
+                                                         $"The algorithm for assigning identities needs to be adjusted." +
+                                                         $"Use an algorithm that guarantees unique identities and is less prone to collisions.");
+                }
             }
 
             _connector?.Logger.Information("Sorting identities done.");
         });
+    }
+}
+
+/// <summary>
+/// Exception thrown when a duplicate identity is detected.
+/// </summary>
+public class DuplicateIdentityException : Exception
+{
+    public DuplicateIdentityException(string message) : base(message)
+    {
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to logging for connection attempts and identity management, and refactors how identities are assigned and written in the `TwinIdentityProvider` class. It also adds error handling for duplicate identities to ensure uniqueness and robustness in identity assignment.

### Logging Enhancements

* Added logging statements to indicate when a connection attempt is made in the `WebApiConnector` constructor, improving traceability of connection operations. [[1]](diffhunk://#diff-7c8eb8de2a83f591484e4db627cb79d1ed5c3a6ef08515d8e00d6ed270834dbdR54-R55) [[2]](diffhunk://#diff-7c8eb8de2a83f591484e4db627cb79d1ed5c3a6ef08515d8e00d6ed270834dbdR101-R102)
* Added logging for identity reading and assignment, providing clearer insight into identity operations.

### Identity Management Refactoring

* Refactored the identity assignment logic in `TwinIdentityProvider` by extracting it into a new method `AssignIdentities`, allowing for customizable identity assignment algorithms and improving code clarity.
* Added a new method `WriteIdentities` to handle writing identities to the PLC, separating concerns and making the workflow more explicit.
* Updated `ConstructIdentitiesAsync` to support custom identity assignment algorithms via an optional parameter, increasing flexibility.

### Error Handling

* Introduced a `DuplicateIdentityException` that is thrown when duplicate identities are detected during sorting, ensuring that assigned identities are unique and providing a clear error message for debugging.

### Minor Code Improvements

* Added minor whitespace and formatting improvements in `WebApiConnector` for readability.

closes #447