### PR TITLE
Update Inxton.Operon package version to 0.2.0-alpha.89

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,6 +75,5 @@
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="System.Interactive" Version="6.0.1" />
-    <PackageVersion Include="Operon" Version="0.2.0-alpha.44" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </GlobalPackageReference>
-    <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.88" />
+    <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.89" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 0.40.1
+next-version: 0.40.2
 branches:
   main:
     regex: ^master$|^main$


### PR DESCRIPTION
This pull request updates the version of the `Inxton.Operon` package referenced in the project. The change ensures the project uses the latest available alpha version of this dependency.

Dependency update:

* Upgraded the `Inxton.Operon` package from version `0.2.0-alpha.88` to `0.2.0-alpha.89` in `Directory.Packages.props`.