### PR TITLE
[FEAT] Compiler should consider conditional pragmas

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AXSharpProject.cs
@@ -101,8 +101,7 @@ public class AXSharpProject : IAXSharpProject
     public void Generate()
     {
         Log.Logger.Information($"Compilation of project '{AxProject.SrcFolder}' started");
-
-        var projectSources = AxProject.Sources.Select(p => (parseTree: STParser.ParseTextAsync(p).Result, source: p));
+        var projectSources = AxProject.Sources.Select(p => (parseTree: STParser.ParseTextAsync(p, SyntaxTreeOptions.Default, this.AxProject.ProjectInfo.Variables?.DefinedPreprocessorSymbols).Result, source: p));
 
         TargetProject.ProvisionProjectStructure();
 

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/Apax.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/Apax.cs
@@ -62,6 +62,12 @@ public class Apax
     public IDictionary<string, string>? Dependencies { get; set; }
 
     /// <summary>
+    ///  Gets or sets variables section.
+    ///  This maps to the `variables` node in apax.yml.
+    /// </summary>
+    public ApaxVariables? Variables { get; set; }
+
+    /// <summary>
     /// Creates new instance of <see cref="Apax"/>.
     /// </summary>
     /// <param name="projectFile">Project file from which the ApaxFile object will be created.</param>
@@ -135,4 +141,22 @@ public class Apax
                 "'apax.yml' file was not found in the working directory. Make sure your current directory is simatic-ax project directory or provide source directory argument (for details see ixc --help)");
         }
     }
+}
+
+/// <summary>
+/// Represents the `variables` section of apax.yml.
+/// </summary>
+public class ApaxVariables
+{
+    /// <summary>
+    /// Values for APAX build arguments. Maps to the YAML key `APAX_BUILD_ARGS`.
+    /// </summary>
+    [YamlMember(Alias = "APAX_BUILD_ARGS", ApplyNamingConventions = false)]
+    public IEnumerable<string>? ApaxBuildArgs { get; set; }
+
+    /// <summary>
+    /// Values for defined preprocessor symbols. Maps to the YAML key `DEFINED_PREPROCESSOR_SYMBOLS`.
+    /// </summary>
+    [YamlMember(Alias = "DEFINED_PREPROCESSOR_SYMBOLS", ApplyNamingConventions = false)]
+    public IEnumerable<string>? DefinedPreprocessorSymbols { get; set; }
 }


### PR DESCRIPTION
This pull request introduces support for handling the `variables` section from the `apax.yml` file in the AXSharp compiler. The main changes involve adding a new `ApaxVariables` class to represent build arguments and preprocessor symbols, updating the `Apax` class to include these variables, and passing the defined preprocessor symbols to the parser during project generation.

Support for apax.yml variables:

* Added a new `ApaxVariables` class to represent the `variables` section in `apax.yml`, including properties for build arguments (`APAX_BUILD_ARGS`) and defined preprocessor symbols (`DEFINED_PREPROCESSOR_SYMBOLS`).
* Updated the `Apax` class to include a `Variables` property, allowing access to the new `ApaxVariables` section.

Integration of preprocessor symbols in project generation:

* Modified the `AXSharpProject.Generate()` method to pass defined preprocessor symbols from `ApaxVariables` to the parser, enabling conditional compilation based on these symbols.

closes #451