### PR TITLE
fix issue with malformed apax.yaml files, skip bin/obj and report proper exception

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Compiler/Apax.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/Apax.cs
@@ -109,6 +109,10 @@ public class Apax
         {
             throw new FileNotFoundException(
                 "'apax.yml' file was not found in the working directory. Make sure your current directory is simatic-ax project directory or provide source directory argument (for details see ixc --help)");
+        }        
+        catch(YamlDotNet.Core.YamlException ex) 
+        {
+            throw new InvalidDataException($"Failed to process apax file: '{projectFile}' {ex.ToString()}");            
         }
     }
 

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/AxProject.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/AxProject.cs
@@ -244,7 +244,7 @@ public class AxProject
 
         nearByProjects = SearchForApaxFiles(GetStartDirectory(this.ProjectFolder, 4), 0, 4)
             .Select(p => new FileInfo(p))
-            .Where(p => !p.Directory.FullName.Contains(".apax"))
+            .Where(p => !(p.Directory.FullName.Contains(".apax") || p.Directory.FullName.Contains("bin") || p.Directory.FullName.Contains("obj")))            
             .Select(a => new NearByProjects() { Apax = Apax.TryCreateApaxDto(a.FullName), ApaxFile = a })
             .ToList(); ;
 

--- a/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
+++ b/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
@@ -4,6 +4,10 @@
       "commandName": "Project",
       "workingDirectory": "c:\\W\\Develop\\gh\\inxton\\statemachine\\"
     },
+    "ixc-tom": {
+      "commandName": "Project",
+      "workingDirectory": "D:\\github\\Inxton\\axopen\\src\\components.elements\\app"
+    },    
     "integration_plc": {
       "commandName": "Project",
       "workingDirectory": "c:\\W\\Develop\\gh\\inxton\\axopen\\src\\integrations\\ctrl\\"


### PR DESCRIPTION
This pull request introduces improvements to error handling, project dependency filtering, and development configuration for the AXSharp compiler. The most important changes are grouped below:

Error Handling Improvements:
* Added specific handling for `YamlException` in `Apax.TryCreateApaxDto`, throwing an `InvalidDataException` with a detailed message when the `apax.yml` file cannot be processed.

Project Dependency Filtering:
* Updated the filtering logic in `AxProject.GetProjectDependencies` to exclude projects located in `bin` and `obj` directories, in addition to `.apax` directories, ensuring only relevant project dependencies are considered.

Development Configuration:
* Added a new launch profile `ixc-tom` to `launchSettings.json` with a specific working directory to facilitate local development and testing.