### PR TITLE
package update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </GlobalPackageReference>
-    <PackageVersion Include="Inxton.Operon" Version="0.2.0-dev-flux.96" />
+    <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.94" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />


### PR DESCRIPTION
This pull request includes a small change to the `Directory.Packages.props` file, updating the version of the `Inxton.Operon` package to ensure compatibility and stability.

* Updated the `Inxton.Operon` package version from `0.2.0-dev-flux.96` to `0.2.0-alpha.94` in `Directory.Packages.props`.