### PR TITLE
[BUG] Missing support exception in ixc when array as type declaration

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Compiler/Core/ICombinedThreeVisitor.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/Core/ICombinedThreeVisitor.cs
@@ -22,7 +22,7 @@ public interface ICombinedThreeVisitor
 {
     public virtual void CreateMergedConfigurations(IxNodeVisitor visitor, Compilation compilation)
     {
-        throw new NotImplementedException();
+        Log.Logger.Information("Merging configurations...");
     }
 
 

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/Core/ICombinedThreeVisitor.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/Core/ICombinedThreeVisitor.cs
@@ -22,7 +22,7 @@ public interface ICombinedThreeVisitor
 {
     public virtual void CreateMergedConfigurations(IxNodeVisitor visitor, Compilation compilation)
     {
-        Log.Logger.Information("Merging configurations...");
+        throw new NotImplementedException();
     }
 
 

--- a/src/AXSharp.compiler/src/AXSharp.Compiler/Core/IxNodeVisitor.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Compiler/Core/IxNodeVisitor.cs
@@ -743,7 +743,22 @@ public partial class IxNodeVisitor : ISyntaxNodeVisitor<ICombinedThreeVisitor>
     void ISyntaxNodeVisitor<ICombinedThreeVisitor>.Accept(IArrayTypeDeclarationSyntax arrayTypeDeclarationSyntax,
         ICombinedThreeVisitor data)
     {
-        throw new NotSupportedException();
+        try
+        {
+            // Read Locations SourceText property using reflection.
+            var locationType = arrayTypeDeclarationSyntax.Location.GetType();
+            var sourceTextProperty = locationType.GetProperty("SourceText");
+            var sourceText = sourceTextProperty?.GetValue(arrayTypeDeclarationSyntax.Location);
+            var sourceTextType = sourceText?.GetType();
+            var fileNameProperty = sourceTextType?.GetProperty("Filename") ?? sourceTextType?.GetProperty("FileName");
+            var fileName = fileNameProperty?.GetValue(sourceText) as string ?? "unknown file";
+
+            Log.Logger.Warning($"Array types as declared in '{fileName}' are not supported at this time.");
+        }
+        catch (Exception)
+        {
+            Log.Logger.Warning($"Array types as declared in 'an unknown location' are not supported at this time.");
+        }                
     }
 
     void ISyntaxNodeVisitor<ICombinedThreeVisitor>.Accept(IAsmStatementSyntax asmStatementSyntax,

--- a/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
+++ b/src/AXSharp.compiler/src/ixc/Properties/launchSettings.json
@@ -40,7 +40,7 @@
     "axopen-traversal": {
       "commandName": "Project",
       "commandLineArgs": "--verbosity Information",
-      "workingDirectory": "C:\\W\\Develop\\gh\\inxton\\simatic-ax\\axopen.templates\\axopen\\src\\traversals\\apax\\"
+      "workingDirectory": "c:\\W\\Develop\\gh\\inxton\\simatic-ax\\axopen-1\\AXOpen\\src\\traversals\\apax\\"
     },
     "axopen-core": {
       "commandName": "Project",

--- a/src/AXSharp.compiler/tests/AXSharp.CompilerTests/Core/IxNodeVisitorTestsSemantics.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.CompilerTests/Core/IxNodeVisitorTestsSemantics.cs
@@ -921,7 +921,7 @@ namespace AXSharp.CompilerTests.Core
             var data = new Mock<ICombinedThreeVisitor>().Object;
 
             // Act
-            Assert.Throws<NotSupportedException>(() => ((ISyntaxNodeVisitor<ICombinedThreeVisitor>)_testClass).Accept(arrayTypeDeclarationSyntax, data));
+            ((ISyntaxNodeVisitor<ICombinedThreeVisitor>)_testClass).Accept(arrayTypeDeclarationSyntax, data);
 
             // Assert
             


### PR DESCRIPTION
This pull request introduces improved error handling and user feedback for unsupported array type declarations, and updates a project launch setting to reflect a new working directory path.

Error handling and logging improvements:

* The `Accept` method for `IArrayTypeDeclarationSyntax` in `IxNodeVisitor.cs` now logs a warning with the filename when array types are declared in unsupported locations, instead of throwing a `NotSupportedException`. It uses reflection to extract the filename from the syntax node, and gracefully handles any exceptions by logging a generic warning.

closes #477