### PR TITLE
Fix ixd throws nre due to missing analizers

### DIFF
--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
@@ -104,6 +104,12 @@ internal class CsOnlinerPlainerOnlineToPlainBuilder : ICombinedThreeVisitor
             case IStringTypeDeclaration stringTypeDeclaration:
                 AddToSource($" plain.{declaration.Name} = {declaration.Name}.LastValue;");
                 break;
+            default:
+                AddToSource($"#pragma warning disable CS0612\n");
+                AddToSource($" plain.{declaration.Name} = await {declaration.Name}.{MethodNameNoac}Async();");
+                AddToSource($"#pragma warning restore CS0612\n");
+                break;
+
         }
     }
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
@@ -114,6 +114,11 @@ internal class CsOnlinerPlainerPlainToOnlineBuilder : ICombinedThreeVisitor
                 AddToSource($" {declaration.Name}.LethargicWrite(plain.{declaration.Name});");
                 AddToSource($"#pragma warning restore CS0612\n");
                 break;
+            default:
+                AddToSource($"#pragma warning disable CS0612\n");
+                AddToSource($" await this.{declaration.Name}.{MethodNameNoac}Async(plain.{declaration.Name});");
+                AddToSource($"#pragma warning restore CS0612\n");
+                break;
         }
     }
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
@@ -101,6 +101,9 @@ namespace AXSharp.Compiler.Cs.Onliner
                 case IStringTypeDeclaration stringTypeDeclaration:
                     AddToSource($" {declaration.Name}.Shadow = plain.{declaration.Name};");
                     break;
+                default:
+                    AddToSource($" await this.{declaration.Name}.{MethodName}Async(plain.{declaration.Name});");
+                    break;
             }
         }
 

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
@@ -100,6 +100,9 @@ namespace AXSharp.Compiler.Cs.Onliner
                 case IStringTypeDeclaration stringTypeDeclaration:
                     AddToSource($" plain.{declaration.Name} = {declaration.Name}.Shadow;");
                     break;
+                default:
+                    AddToSource($" plain.{declaration.Name} = await {declaration.Name}.{MethodName}Async();");
+                    break;
             }
         }
 

--- a/src/AXSharp.compiler/src/ixd/AXSharp.ixd.csproj
+++ b/src/AXSharp.compiler/src/ixd/AXSharp.ixd.csproj
@@ -69,6 +69,10 @@
 			<HintPath>..\..\..\apax\stc\bin\AX.Text.dll</HintPath>
       <Private>False</Private>
 		</Reference>
+		<Reference Include="AX.ST.Compiler.PluginAbstractions">
+			<HintPath>..\..\..\apax\stc\bin\AX.ST.Compiler.PluginAbstractions.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AXSharp.compiler/src/ixd/Program.cs
+++ b/src/AXSharp.compiler/src/ixd/Program.cs
@@ -1,5 +1,6 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using AX.ST.Semantic;
+using AX.ST.Semantic.Analyzer;
 using AX.ST.Syntax.Parser;
 using AX.ST.Syntax.Tree;
 using AX.Text;
@@ -7,17 +8,17 @@ using AX.Text.Diagnostics;
 using AXSharp.Compiler;
 using AXSharp.ixc_doc;
 using AXSharp.ixc_doc.Interfaces;
-using AXSharp.ixc_doc.Visitors;
-using System;
-using CommandLine;
 using AXSharp.ixc_doc.Schemas;
-using System.Reflection;
-using System.Text;
+using AXSharp.ixc_doc.Visitors;
 using CliWrap;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-using System.Collections.Generic;
+using CommandLine;
 using NuGet.Packaging;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
 
 const string Logo =
 @"| \ / 
@@ -75,9 +76,9 @@ void GenerateYamls(Options o)
     //Console.WriteLine($"Compiling project {axProject.ProjectInfo.Name}...");
     //var projectSources = axProject.Sources.Select(p => (parseTree: STParser.ParseTextAsync(p).Result, source: p));
 
-    var toCompile = projectSources.Select(p => p.parseTree);
+    var toCompile = projectSources.Select(p => p.parseTree).ToList();
 
-    var compilation = Compilation.Create(toCompile, null, Compilation.Settings.Default).Result;
+    var compilation = Compilation.Create(toCompile, new List<ISemanticAnalyzer>(), Compilation.Settings.Default).Result;
 
     var semanticTree = compilation.Compilation.GetSemanticTree();
 

--- a/src/AXSharp.compiler/src/ixd/Properties/launchSettings.json
+++ b/src/AXSharp.compiler/src/ixd/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "ixd": {
       "commandName": "Project",
-      "commandLineArgs": "ixd -x C:\\MTS\\ix\\axsharp\\src\\AXSharp.compiler\\src\\ixd\\tests\\samples\\ax\\ -o C:\\MTS\\ix\\axsharp\\src\\AXSharp.compiler\\src\\ixd\\tests\\docfx\\docfx_project\\api\\"
+      "commandLineArgs": "ixd -x .\\src\\abstractions\\ctrl -o .\\docfx\\apictrl\\",
+      "workingDirectory": "c:\\W\\Develop\\gh\\inxton\\simatic-ax\\axopen.templates\\axopen\\"
     },
     "ixd-2": {
       "commandName": "Project",


### PR DESCRIPTION
### Compilation and Analyzer Updates

* Modified the compilation process in `Program.cs` to explicitly pass an empty list of `ISemanticAnalyzer` instances, making the analyzer configuration more explicit and maintainable.

### Usings and Imports Cleanup

* Updated and reorganized `using` statements in `Program.cs` to include new dependencies and remove unused ones, improving code clarity and maintainability.