### PR TITLE
Make resource lookups case-sensitive in Translator.cs

### DIFF
--- a/src/AXSharp.connectors/src/AXSharp.Connector/Localizations/Translator.cs
+++ b/src/AXSharp.connectors/src/AXSharp.Connector/Localizations/Translator.cs
@@ -59,7 +59,7 @@ namespace AXSharp.Connector.Localizations
             {
                 _libraryResourceManager = new ResourceManager(resourceType)
                 {
-                    IgnoreCase = true
+                    IgnoreCase = false
                 };
             }
             else
@@ -180,7 +180,7 @@ namespace AXSharp.Connector.Localizations
         {
             _applicationResourceManager = new ResourceManager(resourceType)
             {
-                IgnoreCase = true
+                IgnoreCase = false
             };
         }
     }


### PR DESCRIPTION
Changed ResourceManager initialization to set IgnoreCase to false
for both _libraryResourceManager and _applicationResourceManager,
enforcing case-sensitive resource key lookups.
