### PR TITLE
Enhance transpilation support for member visibility and data exchange operations

### DIFF
--- a/docfx/articles/compiler/README.md
+++ b/docfx/articles/compiler/README.md
@@ -2,6 +2,15 @@
 
 **AXSharp Compiler (`ixc`) translates PLC data structures into C# (PLC .NET Twin), which makes the PLC data available in a structured way for any .NET application.**
 
+### Member visibility and generated code behavior
+
+AXSharp transpilation now supports members declared as `public`, `protected`, and `internal`.
+
+- **Transpilation / twin generation:** `public`, `protected`, and `internal` members can be generated into twin/onliner classes.
+- **Data exchange (Plain/POCO and Shadow mappings):** only `public` members participate in `OnlineToPlain`, `PlainToOnline`, `ShadowToPlain`, `PlainToShadow`, and related `HasChanged` evaluation.
+
+This means non-public members can exist in generated twins but are intentionally excluded from Plain/Shadow data-transfer operations.
+
 ### Adding types and members to the communication over WebAPI
 
 Starting from the version v2.0.0+ of `sld`, to make member or type accessible over the communication there is a need to add pragma `{S7.extern=ReadWrite}` or `{S7.extern=ReadOnly}` in the appropriate place in the code.

--- a/docfx/articles/connectors/README.md
+++ b/docfx/articles/connectors/README.md
@@ -158,6 +158,9 @@ See also
 
 Shadows are off-line value holders. Each primitive type has a shadow property. This property only affects the Online values if explicitly instructed to do so by the program. Shadows are helpful when we need to modify multiple values, but we need to send them into the PLC in one shot.
 
+> [!NOTE]
+> Data exchange mappings are limited to `public` members. Members transpiled as `protected` or `internal` are not included in Online/Shadow/Plain transfer operations.
+
 ### Sending data from online to shadow
 
 ~~~C#
@@ -179,6 +182,8 @@ See also
 ## Using POCO / Plain object
 
 Onliners are somewhat heavy objects that are well suited for communication with the controller, but they carry too much information that are a burden in some use cases. AXSharp compiler, therefore, creates `Plain/POCO` objects that are light CLR (C#) objects that can retrieve and send data from and to the controller.
+
+Only `public` members are included when converting between online/shadow twins and Plain/POCO objects.
 
 ### Getting POCO object
 

--- a/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/wwwroot/css/operon-variables.css
+++ b/src/AXSharp.blazor/src/AXSharp.Presentation.Blazor.Controls/wwwroot/css/operon-variables.css
@@ -142,7 +142,7 @@
     --color-result-inprogress: #0065B3;
     --color-result-exclude: #7866B9;
     --color-result-bypasse: #912B88;
-    --color-result-inconcllusive: #B58840;
+    --color-result-inconclusive: #B58840;
     --color-result-running: #00A2A3;
     --color-result-noaction: #949494;
     /* #end of result colors*/

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Helpers/SemanticsHelpers.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler
+// AXSharp.Compiler
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -34,8 +34,8 @@ public static class SemanticsHelpers
                                     string coBuilder = "", bool warnMissingOrInconsistent = false)
     {
         var eligibility = field.IsEligibleForTranspile(sourceBuilder, warnMissingOrInconsistent);
-        var isEligible = (field.AccessModifier == AccessModifier.Public
-                            && eligibility.isEligibe
+        var isEligible = ((field.AccessModifier == AccessModifier.Public || field.AccessModifier == AccessModifier.Protected || field.AccessModifier == AccessModifier.Internal)
+                            && eligibility.isEligibe 
                             && !IsToBeOmitted(field, sourceBuilder, coBuilder));
 
         return (isEligible, eligibility.eligibleType);
@@ -362,7 +362,7 @@ public static class SemanticsHelpers
     public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForConstructor(this IFieldDeclaration field, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         var eligibility = field.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
-        return ((field.AccessModifier == AccessModifier.Public && eligibility.isEligible), eligibility.eligibleType);
+        return (eligibility.isEligible, eligibility.eligibleType);
     }
 
     /// <summary>
@@ -375,6 +375,24 @@ public static class SemanticsHelpers
     public static (bool isEligibe, ITypeDeclaration? eligibleType) IsMemberEligibleForConstructor(this IVariableDeclaration variable, ISourceBuilder sourceBuilder, string coBuilder = "")
     {
         return variable.IsMemberEligibleForTranspile(sourceBuilder, coBuilder);
+    }
+
+    /// <summary>
+    ///     Determines whether a field member is eligible for data exchange operations
+    ///     (OnlineToPlain, PlainToOnline, PlainToShadow, ShadowToPlain, HasChanged, and POCO generation).
+    ///     Only public members participate in data exchange; internal and private members are excluded.
+    /// </summary>
+    /// <param name="field">Field declaration</param>
+    /// <param name="sourceBuilder">Source builder</param>
+    /// <param name="coBuilder">Co-builder signature (e.g. POCO, Onliner, etc.)</param>
+    /// <param name="warnMissingOrInconsistent">Issues warning when the type is eligible but not available.</param>
+    /// <returns>True when the member is eligible for data exchange.</returns>
+    public static (bool isEligible, ITypeDeclaration eligibleType) IsMemberEligibleForDataExchange(this IFieldDeclaration field, ISourceBuilder sourceBuilder,
+                                    string coBuilder = "", bool warnMissingOrInconsistent = false)
+    {
+        var eligibility = field.IsMemberEligibleForTranspile(sourceBuilder, coBuilder, warnMissingOrInconsistent);
+        var isEligible = eligibility.isEligible && field.AccessModifier == AccessModifier.Public;
+        return (isEligible, eligibility.eligibleType);
     }
 
     private static bool IsAvailableForComm(this IDeclaration declaration, ISourceBuilder sourceBuilder)

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerOnlineToPlainBuilder.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler.Cs
+// AXSharp.Compiler.Cs
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -36,7 +36,7 @@ internal class CsOnlinerPlainerOnlineToPlainBuilder : ICombinedThreeVisitor
     
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        var eligible = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+        var eligible = fieldDeclaration.IsMemberEligibleForDataExchange(SourceBuilder, "POCO");
         if (eligible.isEligible)
         {
             CreateAssignment(fieldDeclaration.Type, fieldDeclaration);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToOnlineBuilder.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler.Cs
+// AXSharp.Compiler.Cs
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -36,7 +36,7 @@ internal class CsOnlinerPlainerPlainToOnlineBuilder : ICombinedThreeVisitor
     
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+        var eligibility = fieldDeclaration.IsMemberEligibleForDataExchange(SourceBuilder, "POCO");
         if (eligibility.isEligible)
         {
             CreateAssignment(fieldDeclaration.Type, fieldDeclaration);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerPlainToShadowBuilder.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler.Cs
+// AXSharp.Compiler.Cs
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -35,7 +35,7 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
-            var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            var eligibility = fieldDeclaration.IsMemberEligibleForDataExchange(SourceBuilder, "POCO");
             if (eligibility.isEligible)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/CsOnlinerPlainerShadowToPlainBuilder.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler.Cs
+// AXSharp.Compiler.Cs
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -35,7 +35,7 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
-            var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            var eligibility = fieldDeclaration.IsMemberEligibleForDataExchange(SourceBuilder, "POCO");
             if (eligibility.isEligible)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/HasChangedBuilder/CsOnlinerHasChangedBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Onliner/HasChangedBuilder/CsOnlinerHasChangedBuilder.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler.Cs
+// AXSharp.Compiler.Cs
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -35,7 +35,7 @@ namespace AXSharp.Compiler.Cs.Onliner
 
         public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
         {
-            var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(SourceBuilder, "POCO");
+            var eligibility = fieldDeclaration.IsMemberEligibleForDataExchange(SourceBuilder, "POCO");
             if (eligibility.isEligible)
             {
                 CreateAssignment(fieldDeclaration.Type, fieldDeclaration);

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainConstructorBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainConstructorBuilder.cs
@@ -1,4 +1,4 @@
-﻿// AXSharp.Compiler.Cs
+// AXSharp.Compiler.Cs
 // Copyright (c) 2023 MTS spol. s r.o.,  and Contributors. All Rights Reserved.
 // Contributors: https://github.com/inxton/axsharp/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -66,8 +66,8 @@ internal class CsPlainConstructorBuilder : ICombinedThreeVisitor
 
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        var eligibility = fieldDeclaration.IsMemberEligibleForConstructor(SourceBuilder);
-        if (eligibility.isEligibe)
+        var eligibility = fieldDeclaration.IsMemberEligibleForDataExchange(SourceBuilder);
+        if (eligibility.isEligible)
         {
             switch (fieldDeclaration.Type)
             {

--- a/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
+++ b/src/AXSharp.compiler/src/AXSharp.Cs.Compiler/Plain/CsPlainSourceBuilder.cs
@@ -115,9 +115,9 @@ public class CsPlainSourceBuilder : ICombinedThreeVisitor, ISourceBuilder
     /// <inheritdoc />
     public void CreateFieldDeclaration(IFieldDeclaration fieldDeclaration, IxNodeVisitor visitor)
     {
-        var eligibility = fieldDeclaration.IsMemberEligibleForTranspile(this);
+        var eligibility = fieldDeclaration.IsMemberEligibleForDataExchange(this);
         if (eligibility.isEligible)
-        {           
+        {
             AddToSource(fieldDeclaration.Pragmas.AddedPropertiesAsAttributes());
             switch (eligibility.eligibleType)
             {

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/class_with_non_public_members.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/class_with_non_public_members.g.cs
@@ -10,6 +10,10 @@ namespace ClassWithNonTraspilableMemberssNamespace
     public partial class ClassWithNonTraspilableMembers : AXSharp.Connector.ITwinObject
     {
         public ClassWithNonTraspilableMemberssNamespace.ComplexType1 myComplexType { get; }
+        protected ClassWithNonTraspilableMemberssNamespace.ComplexType1 myComplexType1 { get; }
+        protected OnlinerBool myBooool { get; }
+        protected ClassWithNonTraspilableMemberssNamespace.ComplexType1 myComplexType2 { get; }
+        protected OnlinerBool myBooool1 { get; }
 
         partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
         partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
@@ -22,6 +26,10 @@ namespace ClassWithNonTraspilableMemberssNamespace
             HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
             PreConstruct(parent, readableTail, symbolTail);
             myComplexType = new ClassWithNonTraspilableMemberssNamespace.ComplexType1(this, "myComplexType", "myComplexType");
+            myComplexType1 = new ClassWithNonTraspilableMemberssNamespace.ComplexType1(this, "myComplexType1", "myComplexType1");
+            myBooool = @Connector.ConnectorAdapter.AdapterFactory.CreateBOOL(this, "myBooool", "myBooool");
+            myComplexType2 = new ClassWithNonTraspilableMemberssNamespace.ComplexType1(this, "myComplexType2", "myComplexType2");
+            myBooool1 = @Connector.ConnectorAdapter.AdapterFactory.CreateBOOL(this, "myBooool1", "myBooool1");
             parent.AddChild(this);
             parent.AddKid(this);
             PostConstruct(parent, readableTail, symbolTail);

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/mixed_access.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/.g/Onliners/mixed_access.g.cs
@@ -8,6 +8,7 @@ using AXSharp.Abstractions.Presentation;
 public partial class Motor : AXSharp.Connector.ITwinObject
 {
     public OnlinerBool Run { get; }
+    internal OnlinerLReal ActualVelocity { get; }
 
     partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
@@ -20,6 +21,7 @@ public partial class Motor : AXSharp.Connector.ITwinObject
         HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
         PreConstruct(parent, readableTail, symbolTail);
         Run = @Connector.ConnectorAdapter.AdapterFactory.CreateBOOL(this, "Run", "Run");
+        ActualVelocity = @Connector.ConnectorAdapter.AdapterFactory.CreateLREAL(this, "ActualVelocity", "ActualVelocity");
         parent.AddChild(this);
         parent.AddKid(this);
         PostConstruct(parent, readableTail, symbolTail);
@@ -1329,12 +1331,15 @@ public partial class AbstractMotor : AXSharp.Connector.ITwinObject
 
 public partial class GenericMotor : AbstractMotor
 {
+    internal OnlinerLReal ActualVelocity { get; }
+
     partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     public GenericMotor(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail) : base(parent, readableTail, symbolTail)
     {
         Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
         PreConstruct(parent, readableTail, symbolTail);
+        ActualVelocity = @Connector.ConnectorAdapter.AdapterFactory.CreateLREAL(this, "ActualVelocity", "ActualVelocity");
         PostConstruct(parent, readableTail, symbolTail);
     }
 
@@ -1458,12 +1463,15 @@ public partial class GenericMotor : AbstractMotor
 
 public partial class SpecificMotorA : GenericMotor
 {
+    internal OnlinerLReal MaxAcceleration { get; }
+
     partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     public SpecificMotorA(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail) : base(parent, readableTail, symbolTail)
     {
         Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
         PreConstruct(parent, readableTail, symbolTail);
+        MaxAcceleration = @Connector.ConnectorAdapter.AdapterFactory.CreateLREAL(this, "MaxAcceleration", "MaxAcceleration");
         PostConstruct(parent, readableTail, symbolTail);
     }
 

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/units.csproj
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/ax/units.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AXSharp.Abstractions" Version="0.47.0-510-various-additions.440" />
-		<PackageReference Include="AXSharp.Connector" Version="0.47.0-510-various-additions.440" />
+		<PackageReference Include="AXSharp.Abstractions" Version="0.47.0-alpha.459" />
+		<PackageReference Include="AXSharp.Connector" Version="0.47.0-alpha.459" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/class_with_non_public_members.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/class_with_non_public_members.g.cs
@@ -10,6 +10,10 @@ namespace ClassWithNonTraspilableMemberssNamespace
     public partial class ClassWithNonTraspilableMembers : AXSharp.Connector.ITwinObject
     {
         public ClassWithNonTraspilableMemberssNamespace.ComplexType1 myComplexType { get; }
+        protected ClassWithNonTraspilableMemberssNamespace.ComplexType1 myComplexType1 { get; }
+        protected OnlinerBool myBooool { get; }
+        protected ClassWithNonTraspilableMemberssNamespace.ComplexType1 myComplexType2 { get; }
+        protected OnlinerBool myBooool1 { get; }
 
         partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
         partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
@@ -22,6 +26,10 @@ namespace ClassWithNonTraspilableMemberssNamespace
             HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
             PreConstruct(parent, readableTail, symbolTail);
             myComplexType = new ClassWithNonTraspilableMemberssNamespace.ComplexType1(this, "myComplexType", "myComplexType");
+            myComplexType1 = new ClassWithNonTraspilableMemberssNamespace.ComplexType1(this, "myComplexType1", "myComplexType1");
+            myBooool = @Connector.ConnectorAdapter.AdapterFactory.CreateBOOL(this, "myBooool", "myBooool");
+            myComplexType2 = new ClassWithNonTraspilableMemberssNamespace.ComplexType1(this, "myComplexType2", "myComplexType2");
+            myBooool1 = @Connector.ConnectorAdapter.AdapterFactory.CreateBOOL(this, "myBooool1", "myBooool1");
             parent.AddChild(this);
             parent.AddKid(this);
             PostConstruct(parent, readableTail, symbolTail);

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/mixed_access.g.cs
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/.g/Onliners/mixed_access.g.cs
@@ -8,6 +8,7 @@ using AXSharp.Abstractions.Presentation;
 public partial class Motor : AXSharp.Connector.ITwinObject
 {
     public OnlinerBool Run { get; }
+    internal OnlinerLReal ActualVelocity { get; }
 
     partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
@@ -20,6 +21,7 @@ public partial class Motor : AXSharp.Connector.ITwinObject
         HumanReadable = AXSharp.Connector.Connector.CreateHumanReadable(parent.HumanReadable, readableTail);
         PreConstruct(parent, readableTail, symbolTail);
         Run = @Connector.ConnectorAdapter.AdapterFactory.CreateBOOL(this, "Run", "Run");
+        ActualVelocity = @Connector.ConnectorAdapter.AdapterFactory.CreateLREAL(this, "ActualVelocity", "ActualVelocity");
         parent.AddChild(this);
         parent.AddKid(this);
         PostConstruct(parent, readableTail, symbolTail);
@@ -1329,12 +1331,15 @@ public partial class AbstractMotor : AXSharp.Connector.ITwinObject
 
 public partial class GenericMotor : AbstractMotor
 {
+    internal OnlinerLReal ActualVelocity { get; }
+
     partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     public GenericMotor(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail) : base(parent, readableTail, symbolTail)
     {
         Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
         PreConstruct(parent, readableTail, symbolTail);
+        ActualVelocity = @Connector.ConnectorAdapter.AdapterFactory.CreateLREAL(this, "ActualVelocity", "ActualVelocity");
         PostConstruct(parent, readableTail, symbolTail);
     }
 
@@ -1458,12 +1463,15 @@ public partial class GenericMotor : AbstractMotor
 
 public partial class SpecificMotorA : GenericMotor
 {
+    internal OnlinerLReal MaxAcceleration { get; }
+
     partial void PreConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     partial void PostConstruct(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail);
     public SpecificMotorA(AXSharp.Connector.ITwinObject parent, string readableTail, string symbolTail) : base(parent, readableTail, symbolTail)
     {
         Symbol = AXSharp.Connector.Connector.CreateSymbol(parent.Symbol, symbolTail);
         PreConstruct(parent, readableTail, symbolTail);
+        MaxAcceleration = @Connector.ConnectorAdapter.AdapterFactory.CreateLREAL(this, "MaxAcceleration", "MaxAcceleration");
         PostConstruct(parent, readableTail, symbolTail);
     }
 

--- a/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/units.csproj
+++ b/src/AXSharp.compiler/tests/AXSharp.Compiler.CsTests/samples/units/expected/tia/units.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AXSharp.Abstractions" Version="0.47.0-496-bug-componentgetattributename-return-null.399" />
-		<PackageReference Include="AXSharp.Connector" Version="0.47.0-496-bug-componentgetattributename-return-null.399" />
+		<PackageReference Include="AXSharp.Abstractions" Version="0.47.0-alpha.459" />
+		<PackageReference Include="AXSharp.Connector" Version="0.47.0-alpha.459" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updated documentation to clarify that `public`, `protected`, and `internal` members are now supported in transpilation.
- Adjusted data exchange logic to ensure only `public` members participate in operations like `OnlineToPlain` and `PlainToOnline`.
- Refactored eligibility checks in the code to include `protected` and `internal` members for transpilation but exclude them from data exchange.
- Updated generated code to reflect changes in member visibility handling.
